### PR TITLE
docs: ✏️ Add Letter Sealing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ with `Error when logging in: Internal error`.
 4. Try logging in to the bridge again.
 
 > [!NOTE]
+>
 > - The `Letter Sealing` setting is only configurable from the LINE
 >   mobile app.
 > - Once the setting's turned on it can't be turned off.


### PR DESCRIPTION
## Summary

Update the README `Can't log in?` section to document that LINE login can fail if `Letter Sealing` is disabled, and keep the existing guidance for accounts without an email address set.

I used this for the markdownlint: https://github.com/igorshubovych/markdownlint-cli

```
$ markdownlint --version
0.48.0

$ markdownlint README.md
```

###  Scope

- Add new section to README.md
- Fixed linting on `README.md` content that had `markdownlint` warnings

###  Out of Scope

- Unrelated `README.md` content updates

## Issue

Relates to #42