### PR TITLE
dev: 🛠️ improve docker incremental build caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,13 @@ data/
 .git/**
 .idea
 .vscode
+.github
+.github/**
+
+# Files not needed to compile or run the image
+README.md
+LICENSE
+.pre-commit-config.yaml
+build.sh
+build-windows.sh
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 ARG DOCKER_HUB="docker.io"
 
 FROM ${DOCKER_HUB}/alpine:3.23 AS builder
@@ -5,12 +7,19 @@ FROM ${DOCKER_HUB}/alpine:3.23 AS builder
 RUN apk add --no-cache go git build-base olm-dev
 
 WORKDIR /build
+ENV GOPATH=/go \
+    GOMODCACHE=/go/pkg/mod \
+    GOCACHE=/root/.cache/go-build
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-COPY . .
-RUN go build -o matrix-line ./cmd/matrix-line
+COPY cmd ./cmd
+COPY pkg ./pkg
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o matrix-line ./cmd/matrix-line
 
 FROM ${DOCKER_HUB}/alpine:3.23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.22
 
 ARG DOCKER_HUB="docker.io"
 


### PR DESCRIPTION
**Summary**

Improve Docker incremental build times by making the Go build more cache-friendly and reducing unnecessary build context invalidation.

TL;DR subsequent "docker compose up --build -d" runs finish in ~9s instead of ~300s

**What changed**

- Enabled a modern Dockerfile frontend so BuildKit cache mounts can be used
- Added persistent cache mounts for:
  - Go module downloads
  - Go build artifacts
- Narrowed the builder stage source copy to `cmd/` and `pkg/` instead of copying the whole repo
- Expanded `.dockerignore` to exclude files that are not needed to build or run the image, like docs, Git metadata, and local tooling config

**Why**

The Dockerfile already copied `go.mod`/`go.sum` first, but rebuilds could still do more work than necessary. These changes help in two ways:

- Reuse downloaded modules and compiled package cache across builds
- Avoid invalidating the compile layer when unrelated files change

This should make iterative `docker compose build matrix-line` runs noticeably faster during development.

**Testing**

ℹ️ on linux

- Verified the Dockerfile and ignore-file changes are scoped to the build path
- Could not run `docker compose build` in the current workspace because Docker was not available there
- A host-side `go build` was also not a full substitute because local `libolm` headers were unavailable outside the container

👍 Subsequent builds take 9s as opposed to more than 300s (on my weakling linux home server)