### PR TITLE
feat: 🐛 show proper error when logging in with letter sealing off

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -187,12 +187,19 @@ func (lc *LineClient) tryLogin(ctx context.Context) error {
 	client := line.NewClient("")
 	res, err := client.Login(email, password, certificate)
 	if err != nil {
+		if line.IsLetterSealingRequired(err) {
+			return fmt.Errorf("%w: %s", line.ErrLetterSealingRequired, letterSealingRequiredLoginMessage())
+		}
+		lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Stored-credential LINE login failed")
 		return fmt.Errorf("login failed: %w", err)
 	}
 	if res.AuthToken == "" {
 		pin := res.Pin
 		if res.PinCode != "" {
 			pin = res.PinCode
+		}
+		if isLetterSealingLoginFailure(res) {
+			return fmt.Errorf("%w: %s", line.ErrLetterSealingRequired, letterSealingRequiredLoginMessage())
 		}
 		if pin != "" {
 			lc.UserLogin.Bridge.Log.Warn().Msg("PIN verification required — check your LINE mobile app to complete re-login")
@@ -211,10 +218,13 @@ func (lc *LineClient) tryLogin(ctx context.Context) error {
 		waitClient := line.NewClient("")
 		waitRes, err := waitClient.WaitForLogin(res.Verifier)
 		if err != nil {
+			if line.IsLetterSealingRequired(err) {
+				return fmt.Errorf("%w: %s", line.ErrLetterSealingRequired, letterSealingRequiredLoginMessage())
+			}
 			return fmt.Errorf("PIN verification failed: %w", err)
 		}
 		if waitRes.AuthToken == "" {
-			return fmt.Errorf("PIN verification completed but no auth token received")
+			return fmt.Errorf("%w: %s", line.ErrLetterSealingRequired, letterSealingRequiredLoginMessage())
 		}
 		// Replace res with the verified result
 		res = waitRes

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -166,6 +166,10 @@ func (ll *LineEmailLogin) SubmitUserInput(ctx context.Context, input map[string]
 	client := line.NewClient("")
 	res, err := client.Login(ll.Email, ll.Password, "")
 	if err != nil {
+		if line.IsLetterSealingRequired(err) {
+			return ll.loginErrorStep(letterSealingRequiredLoginMessage()), nil
+		}
+		ll.User.Log.Warn().Err(err).Msg("LINE login failed during interactive login")
 		reason := loginErrorReason(err)
 		if reason == "" {
 			reason = fmt.Sprintf("Login failed: %v", err)
@@ -174,6 +178,17 @@ func (ll *LineEmailLogin) SubmitUserInput(ctx context.Context, input map[string]
 	}
 
 	return ll.handleLoginResponse(ctx, res)
+}
+
+func letterSealingRequiredLoginMessage() string {
+	return "This LINE account can't log in to the bridge until Letter Sealing is enabled in the LINE app. Enable it in LINE -> Settings -> Privacy -> Letter Sealing, then try again. For more info check [github](https://github.com/highesttt/matrix-line-messenger?tab=readme-ov-file#2-letter-sealing-end-to-end-encryption-is-disabled)."
+}
+
+func isLetterSealingLoginFailure(res *line.LoginResult) bool {
+	if res == nil || res.AuthToken != "" || res.Verifier != "" {
+		return false
+	}
+	return res.Pin != "" || res.PinCode != ""
 }
 
 func (ll *LineEmailLogin) loginErrorStep(message string) *bridgev2.LoginStep {
@@ -227,8 +242,11 @@ func (ll *LineEmailLogin) Wait(ctx context.Context) (*bridgev2.LoginStep, error)
 			if res.AuthToken != "" {
 				return ll.finishLogin(ctx, res)
 			}
-			return nil, fmt.Errorf("verification failed: no auth token received")
+			return ll.loginErrorStep(letterSealingRequiredLoginMessage()), nil
 		case err := <-ll.pollErr:
+			if line.IsLetterSealingRequired(err) {
+				return ll.loginErrorStep(letterSealingRequiredLoginMessage()), nil
+			}
 			return nil, fmt.Errorf("verification failed: %w", err)
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -239,6 +257,10 @@ func (ll *LineEmailLogin) Wait(ctx context.Context) (*bridgev2.LoginStep, error)
 		client := line.NewClient("")
 		res, err := client.Login(ll.Email, ll.Password, "")
 		if err != nil {
+			if line.IsLetterSealingRequired(err) {
+				return ll.loginErrorStep(letterSealingRequiredLoginMessage()), nil
+			}
+			ll.User.Log.Warn().Err(err).Msg("LINE login continuation failed during interactive login")
 			return nil, fmt.Errorf("login failed: %w", err)
 		}
 		return ll.handleLoginResponse(ctx, res)
@@ -250,6 +272,10 @@ func (ll *LineEmailLogin) Wait(ctx context.Context) (*bridgev2.LoginStep, error)
 func (ll *LineEmailLogin) handleLoginResponse(ctx context.Context, res *line.LoginResult) (*bridgev2.LoginStep, error) {
 	if res.AuthToken != "" {
 		return ll.finishLogin(ctx, res)
+	}
+
+	if isLetterSealingLoginFailure(res) {
+		return ll.loginErrorStep(letterSealingRequiredLoginMessage()), nil
 	}
 
 	if (res.Type == 3 || res.Type == 0) && res.Verifier != "" {

--- a/pkg/line/client.go
+++ b/pkg/line/client.go
@@ -62,6 +62,9 @@ func (c *Client) Login(email, pass, certificate string) (*LoginResult, error) {
 		respBytes, err = c.LoginV2WithType(0, rsaKey.KeyName, encryptedPass, "", "")
 	}
 	if err != nil {
+		if isLetterSealingLoginAPIError(err) {
+			return nil, fmt.Errorf("%w: %v", ErrLetterSealingRequired, err)
+		}
 		return nil, fmt.Errorf("login failed: %w", err)
 	}
 
@@ -170,7 +173,7 @@ func (c *Client) WaitForLogin(verifier string) (*LoginResult, error) {
 		}, nil
 	}
 
-	return nil, fmt.Errorf("polling returned without success")
+	return nil, fmt.Errorf("%w: polling returned without success", ErrLetterSealingRequired)
 }
 
 func (c *Client) GetRSAKeyInfo() (*RSAKeyInfo, error) {

--- a/pkg/line/errors.go
+++ b/pkg/line/errors.go
@@ -1,0 +1,78 @@
+package line
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+var ErrLetterSealingRequired = errors.New("letter sealing must be enabled")
+
+type talkExceptionData struct {
+	Name    string `json:"name"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+	Reason  string `json:"reason"`
+}
+
+func parseTalkExceptionData(raw json.RawMessage) talkExceptionData {
+	var data talkExceptionData
+	_ = json.Unmarshal(raw, &data)
+	return data
+}
+
+func parseHTTPAPIError(err error) (int, json.RawMessage, bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+
+	msg := err.Error()
+	idx := strings.Index(msg, "API error ")
+	if idx == -1 {
+		return 0, nil, false
+	}
+
+	rest := msg[idx+len("API error "):]
+	statusText, bodyText, ok := strings.Cut(rest, ": ")
+	if !ok {
+		return 0, nil, false
+	}
+
+	status, convErr := strconv.Atoi(statusText)
+	if convErr != nil {
+		return 0, nil, false
+	}
+
+	return status, json.RawMessage(bodyText), true
+}
+
+func isLetterSealingLoginAPIError(err error) bool {
+	status, body, ok := parseHTTPAPIError(err)
+	if !ok || status != 400 {
+		return false
+	}
+
+	var wrapper struct {
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if jsonErr := json.Unmarshal(body, &wrapper); jsonErr != nil {
+		return false
+	}
+
+	talk := parseTalkExceptionData(wrapper.Data)
+	return wrapper.Code == 10051 &&
+		strings.EqualFold(wrapper.Message, "RESPONSE_ERROR") &&
+		strings.EqualFold(talk.Name, "TalkException") &&
+		talk.Code == 20 &&
+		strings.EqualFold(talk.Reason, "internal error")
+}
+
+func IsLetterSealingRequired(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, ErrLetterSealingRequired) || isLetterSealingLoginAPIError(err)
+}


### PR DESCRIPTION
## Summary

- surface a specific login error when the bridge account has Letter Sealing disabled
- treat the known PIN and polling failure shape as a clean Letter Sealing requirement instead of a generic internal error
- keep this PR scoped to the login flow only

## Testing

- `go test ./pkg/...`
- `go test ./...` is blocked locally because `olm/olm.h` is not installed on this machine

## Merge Order

- merge this before the LSON decrypting/messages PR

Split from https://github.com/highesttt/matrix-line-messenger/pull/56