### PR TITLE
feat: 🐛 better error handling for letter sealing messages

### DIFF
--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -24,19 +24,17 @@ func (lc *LineClient) fetchAndUnwrapGroupKey(ctx context.Context, chatMid string
 	}
 
 	sharedKey, err := fetch()
-	if err != nil && (lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
-		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+	if err != nil && lc.isRefreshRequired(err) {
+		if errRefresh := lc.refreshAndSave(ctx); errRefresh == nil {
 			client = line.NewClient(lc.AccessToken)
 			sharedKey, err = fetch()
-		} else {
-			return fmt.Errorf("failed to recover token before fetching group key: %w", errRecover)
 		}
 	}
 	if err != nil {
 		return err
 	}
 	if sharedKey == nil {
-		return fmt.Errorf("no group shared key returned for %s", chatMid)
+		return fmt.Errorf("%w: no group shared key returned for %s", line.ErrNoUsableE2EEGroupKey, chatMid)
 	}
 
 	lc.UserLogin.Bridge.Log.Debug().
@@ -68,7 +66,7 @@ func (lc *LineClient) fetchAndUnwrapGroupKey(ctx context.Context, chatMid string
 	return nil
 }
 
-func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string, error) {
+func (lc *LineClient) ensurePeerKey(ctx context.Context, mid string) (int, string, error) {
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
@@ -80,6 +78,12 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 	}
 	client := line.NewClient(lc.AccessToken)
 	res, err := client.NegotiateE2EEPublicKey(mid)
+	if err != nil && (lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
+		if errRefresh := lc.refreshAndSave(ctx); errRefresh == nil {
+			client = line.NewClient(lc.AccessToken)
+			res, err = client.NegotiateE2EEPublicKey(mid)
+		}
+	}
 	if err != nil {
 		return 0, "", err
 	}
@@ -95,7 +99,7 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 	return pk.raw, pk.pub, nil
 }
 
-func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int) (int, string, error) {
+func (lc *LineClient) ensurePeerKeyByID(ctx context.Context, mid string, keyID int) (int, string, error) {
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
@@ -109,6 +113,12 @@ func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int
 	client := line.NewClient(lc.AccessToken)
 	// keyVersion 1
 	res, err := client.GetE2EEPublicKey(mid, 1, keyID)
+	if err != nil && (lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
+		if errRefresh := lc.refreshAndSave(ctx); errRefresh == nil {
+			client = line.NewClient(lc.AccessToken)
+			res, err = client.GetE2EEPublicKey(mid, 1, keyID)
+		}
+	}
 	if err != nil {
 		return 0, "", err
 	}

--- a/pkg/connector/letter_sealing.go
+++ b/pkg/connector/letter_sealing.go
@@ -1,0 +1,46 @@
+package connector
+
+import (
+	"errors"
+
+	"maunium.net/go/mautrix/bridgev2"
+	"maunium.net/go/mautrix/bridgev2/status"
+	"maunium.net/go/mautrix/event"
+
+	"github.com/highesttt/matrix-line-messenger/pkg/line"
+)
+
+func wrapLetterSealingSendError(portalMid string, isGroup bool, err error) error {
+	if err == nil {
+		return nil
+	}
+	if isGroup && line.IsNoUsableE2EEGroupKey(err) {
+		message := "This LINE group can't be bridged because it doesn't expose usable Letter Sealing keys. At least one participant likely has Letter Sealing disabled."
+		internalMessage := "line group can't be bridged because it doesn't expose usable letter sealing keys"
+		return bridgev2.MessageStatus{
+			Step:           status.MsgStepRemote,
+			Status:         event.MessageStatusFail,
+			ErrorReason:    event.MessageStatusUnsupported,
+			InternalError:  errors.New(internalMessage),
+			Message:        message,
+			ErrorAsMessage: true,
+			SendNotice:     true,
+			IsCertain:      true,
+		}
+	}
+	if !isGroup && line.IsNoUsableE2EEPublicKey(err) {
+		message := "This LINE chat can't be bridged because the recipient doesn't expose a usable Letter Sealing key. They likely have Letter Sealing disabled."
+		internalMessage := "line chat can't be bridged because the recipient doesn't expose a usable letter sealing key"
+		return bridgev2.MessageStatus{
+			Step:           status.MsgStepRemote,
+			Status:         event.MessageStatusFail,
+			ErrorReason:    event.MessageStatusUnsupported,
+			InternalError:  errors.New(internalMessage),
+			Message:        message,
+			ErrorAsMessage: true,
+			SendNotice:     true,
+			IsCertain:      true,
+		}
+	}
+	return err
+}

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -331,21 +331,19 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 	isGroup := strings.HasPrefix(lowerPortalID, "c") || strings.HasPrefix(lowerPortalID, "r")
 
 	if isGroup {
-		if errFetch := lc.fetchAndUnwrapGroupKey(ctx, portalMid, 0); errFetch != nil {
-			lc.UserLogin.Bridge.Log.Debug().Err(errFetch).Str("chat_mid", portalMid).Msg("fetchAndUnwrapGroupKey before encrypt failed")
-		}
 		if contentType != int(ContentText) {
 			chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
 		} else {
 			chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
 		}
 		if err != nil {
-			if errFetch := lc.fetchAndUnwrapGroupKey(ctx, portalMid, 0); errFetch == nil {
-				if contentType != int(ContentText) {
-					chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
-				} else {
-					chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
-				}
+			if errFetch := lc.fetchAndUnwrapGroupKey(ctx, portalMid, 0); errFetch != nil {
+				return nil, wrapLetterSealingSendError(portalMid, true, errFetch)
+			}
+			if contentType != int(ContentText) {
+				chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
+			} else {
+				chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
 			}
 		}
 	} else {
@@ -356,14 +354,14 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		}
 		peerRaw, peerPub, errPeer := lc.ensurePeerKey(ctx, portalMid)
 		if errPeer != nil {
-			return nil, fmt.Errorf("failed to get peer key: %w", errPeer)
+			return nil, wrapLetterSealingSendError(portalMid, false, fmt.Errorf("failed to get peer key: %w", errPeer))
 		}
 
 		chunks, err = lc.E2EE.EncryptMessageV2Raw(portalMid, fromMid, myKeyID, peerPub, myRaw, peerRaw, contentType, payload)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("encrypt failed: %w", err)
+		return nil, wrapLetterSealingSendError(portalMid, isGroup, fmt.Errorf("encrypt failed: %w", err))
 	}
 
 	now := time.Now().UnixMilli()

--- a/pkg/line/client.go
+++ b/pkg/line/client.go
@@ -239,7 +239,7 @@ func (c *Client) callRPC(service, method string, args ...interface{}) ([]byte, e
 	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+		return nil, parseAPIError(resp.StatusCode, respBody)
 	}
 
 	return respBody, nil

--- a/pkg/line/errors.go
+++ b/pkg/line/errors.go
@@ -1,0 +1,109 @@
+package line
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrNoUsableE2EEPublicKey = errors.New("no usable E2EE public key")
+	ErrNoUsableE2EEGroupKey  = errors.New("no usable E2EE group key")
+)
+
+type talkExceptionData struct {
+	Name    string `json:"name"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+	Reason  string `json:"reason"`
+}
+
+type apiError struct {
+	HTTPStatus int
+	Code       int
+	Message    string
+	Talk       talkExceptionData
+	RawBody    string
+
+	kind error
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("API error %d: %s", e.HTTPStatus, e.RawBody)
+}
+
+func (e *apiError) Unwrap() error {
+	return e.kind
+}
+
+func parseAPIError(status int, body []byte) error {
+	apiErr := &apiError{
+		HTTPStatus: status,
+		RawBody:    string(body),
+	}
+
+	var wrapper struct {
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		return apiErr
+	}
+
+	apiErr.Code = wrapper.Code
+	apiErr.Message = wrapper.Message
+	apiErr.Talk = parseTalkExceptionData(wrapper.Data)
+	if isNoUsableE2EEGroupKeyTalkException(wrapper.Message, apiErr.Talk) {
+		apiErr.kind = ErrNoUsableE2EEGroupKey
+	}
+
+	return apiErr
+}
+
+func parseTalkExceptionData(raw json.RawMessage) talkExceptionData {
+	var data talkExceptionData
+	_ = json.Unmarshal(raw, &data)
+	return data
+}
+
+func isNoUsableE2EEGroupKeyTalkException(message string, data talkExceptionData) bool {
+	return strings.EqualFold(message, "RESPONSE_ERROR") &&
+		strings.EqualFold(data.Name, "TalkException") &&
+		data.Code == 5 &&
+		strings.EqualFold(data.Reason, "not found")
+}
+
+func parseE2EEGroupKeyError(method, message string, rawData json.RawMessage) error {
+	talk := parseTalkExceptionData(rawData)
+	if isNoUsableE2EEGroupKeyTalkException(message, talk) {
+		return fmt.Errorf("%w: %s", ErrNoUsableE2EEGroupKey, talk.Reason)
+	}
+	return fmt.Errorf("%s failed: %s", method, message)
+}
+
+func IsNoUsableE2EEPublicKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrNoUsableE2EEPublicKey) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "missing fields (pub=false keyID=-1") ||
+		strings.Contains(msg, "missing fields (pub=false keyID=0") ||
+		strings.Contains(msg, "\"allowedTypes\":[]") && strings.Contains(msg, "\"specVersion\":-1")
+}
+
+func IsNoUsableE2EEGroupKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrNoUsableE2EEGroupKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no group key found") ||
+		strings.Contains(msg, "no group shared key returned")
+}

--- a/pkg/line/methods.go
+++ b/pkg/line/methods.go
@@ -119,17 +119,21 @@ func (c *Client) GetE2EEGroupSharedKey(chatMid string, groupKeyID int) (*E2EEGro
 		return nil, err
 	}
 	var wrapper struct {
-		Code    int                `json:"code"`
-		Message string             `json:"message"`
-		Data    E2EEGroupSharedKey `json:"data"`
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(resp, &wrapper); err != nil {
 		return nil, err
 	}
 	if wrapper.Code != 0 {
-		return nil, fmt.Errorf("getE2EEGroupSharedKey failed: %s", wrapper.Message)
+		return nil, parseE2EEGroupKeyError("getE2EEGroupSharedKey", wrapper.Message, wrapper.Data)
 	}
-	return &wrapper.Data, nil
+	var data E2EEGroupSharedKey
+	if err := json.Unmarshal(wrapper.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
 }
 
 func (c *Client) GetLastE2EEGroupSharedKey(chatMid string) (*E2EEGroupSharedKey, error) {
@@ -138,17 +142,21 @@ func (c *Client) GetLastE2EEGroupSharedKey(chatMid string) (*E2EEGroupSharedKey,
 		return nil, err
 	}
 	var wrapper struct {
-		Code    int                `json:"code"`
-		Message string             `json:"message"`
-		Data    E2EEGroupSharedKey `json:"data"`
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(resp, &wrapper); err != nil {
 		return nil, err
 	}
 	if wrapper.Code != 0 {
-		return nil, fmt.Errorf("getLastE2EEGroupSharedKey failed: %s", wrapper.Message)
+		return nil, parseE2EEGroupKeyError("getLastE2EEGroupSharedKey", wrapper.Message, wrapper.Data)
 	}
-	return &wrapper.Data, nil
+	var data E2EEGroupSharedKey
+	if err := json.Unmarshal(wrapper.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
 }
 
 // NegotiateE2EEPublicKey fetches (or renews) the public key of the person you're talking to (E2EE).
@@ -279,7 +287,7 @@ func parseE2EEPublicKey(rawData []byte) (*E2EEPublicKey, error) {
 		keyID = findInt64(data)
 	}
 	if pub == "" || keyID == 0 {
-		return nil, fmt.Errorf("missing fields (pub=%t keyID=%d raw=%s)", pub != "", keyID, string(rawData))
+		return nil, fmt.Errorf("%w: missing fields (pub=%t keyID=%d raw=%s)", ErrNoUsableE2EEPublicKey, pub != "", keyID, string(rawData))
 	}
 
 	return &E2EEPublicKey{


### PR DESCRIPTION
## Summary

- tighten detection of missing usable Letter Sealing public and group keys in the message path
- stop retrying token recovery when the real failure is missing E2EE key material
- return clearer unsupported-chat statuses for these Letter Sealing message failures
- keep this PR scoped to the message/decrypting path only

## Testing

- `go test ./pkg/...`
- `go test ./...` is blocked locally because `olm/olm.h` is not installed on this machine

## Merge Order

- merge this after the LSOFF login PR to minimize conflicts
- both code PRs add `pkg/line/errors.go`, so GitHub will likely show a merge conflict unless the later PR is rebased after the first one lands

Split from https://github.com/highesttt/matrix-line-messenger/pull/56