### PR TITLE
feat: plain text fallback for Letter Sealing OFF peers

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -28,12 +28,15 @@ type LineClient struct {
 	reqSeqMu    sync.Mutex
 	sentReqSeqs map[int]time.Time
 
+	noE2EEGroups map[string]time.Time // chatMid -> when group E2EE failure was cached
 	contactCache map[string]line.Contact
 }
 
 type peerKeyInfo struct {
-	raw int
-	pub string
+	raw       int
+	pub       string
+	noE2EE    bool      // true if peer has Letter Sealing off
+	checkedAt time.Time // when noE2EE was last verified
 }
 
 var _ bridgev2.NetworkAPI = (*LineClient)(nil)

--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -3,10 +3,13 @@ package connector
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/highesttt/matrix-line-messenger/pkg/e2ee"
 	"github.com/highesttt/matrix-line-messenger/pkg/line"
 )
+
+const noE2EETTL = 1 * time.Hour
 
 // fetchAndUnwrapGroupKey retrieves a specific group key (or the latest when groupKeyID == 0)
 // and unwraps it so the E2EE manager can encrypt/decrypt group messages.
@@ -24,7 +27,9 @@ func (lc *LineClient) fetchAndUnwrapGroupKey(ctx context.Context, chatMid string
 	}
 
 	sharedKey, err := fetch()
-	if err != nil && (lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
+	// Don't attempt token recovery if the error is actually a "no E2EE group key" error
+	// (e.g., TalkException code 1/5/98 wrapped in a 10051 HTTP error).
+	if err != nil && !line.IsNoUsableE2EEGroupKey(err) && (lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
 		if errRecover := lc.recoverToken(ctx); errRecover == nil {
 			client = line.NewClient(lc.AccessToken)
 			sharedKey, err = fetch()
@@ -72,15 +77,28 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
-	if cached, ok := lc.peerKeys[mid]; ok && cached.raw != 0 && cached.pub != "" {
-		if lc.E2EE != nil {
-			lc.E2EE.RegisterPeerPublicKey(cached.raw, cached.pub)
+	if cached, ok := lc.peerKeys[mid]; ok {
+		// Cached as Letter Sealing off — return error unless TTL expired
+		if cached.noE2EE {
+			if time.Since(cached.checkedAt) < noE2EETTL {
+				return 0, "", line.ErrNoUsableE2EEPublicKey
+			}
+			// TTL expired, re-negotiate below
+		} else if cached.raw != 0 && cached.pub != "" {
+			if lc.E2EE != nil {
+				lc.E2EE.RegisterPeerPublicKey(cached.raw, cached.pub)
+			}
+			return cached.raw, cached.pub, nil
 		}
-		return cached.raw, cached.pub, nil
 	}
 	client := line.NewClient(lc.AccessToken)
 	res, err := client.NegotiateE2EEPublicKey(mid)
 	if err != nil {
+		// Cache negative result so we don't keep hitting the API
+		if line.IsNoUsableE2EEPublicKey(err) {
+			lc.peerKeys[mid] = peerKeyInfo{noE2EE: true, checkedAt: time.Now()}
+			lc.UserLogin.Bridge.Log.Info().Str("peer", mid).Msg("Peer has Letter Sealing disabled, will send plain text")
+		}
 		return 0, "", err
 	}
 	keyID, err := res.KeyID.Int64()
@@ -93,6 +111,28 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 		lc.E2EE.RegisterPeerPublicKey(pk.raw, pk.pub)
 	}
 	return pk.raw, pk.pub, nil
+}
+
+// isGroupNoE2EE checks if a group is cached as having no E2EE shared key.
+func (lc *LineClient) isGroupNoE2EE(chatMid string) bool {
+	if lc.noE2EEGroups == nil {
+		return false
+	}
+	checkedAt, ok := lc.noE2EEGroups[chatMid]
+	return ok && time.Since(checkedAt) < noE2EETTL
+}
+
+// markGroupNoE2EE caches a group as having no E2EE shared key.
+func (lc *LineClient) markGroupNoE2EE(chatMid string) {
+	if lc.noE2EEGroups == nil {
+		lc.noE2EEGroups = make(map[string]time.Time)
+	}
+	lc.noE2EEGroups[chatMid] = time.Now()
+}
+
+// clearGroupNoE2EE removes a group from the noE2EE cache (e.g., when we receive encrypted messages).
+func (lc *LineClient) clearGroupNoE2EE(chatMid string) {
+	delete(lc.noE2EEGroups, chatMid)
 }
 
 func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int) (int, string, error) {
@@ -135,6 +175,16 @@ func (lc *LineClient) ensurePeerKeyForMessage(ctx context.Context, msg *line.Mes
 	if lc.E2EE == nil || len(msg.Chunks) < 5 {
 		return
 	}
+
+	// If we receive an encrypted message from a peer we cached as noE2EE,
+	// they must have enabled Letter Sealing — invalidate the cache.
+	if lc.peerKeys != nil {
+		if cached, ok := lc.peerKeys[msg.From]; ok && cached.noE2EE {
+			lc.UserLogin.Bridge.Log.Info().Str("peer", msg.From).Msg("Received encrypted message from peer previously cached as noE2EE, invalidating cache")
+			delete(lc.peerKeys, msg.From)
+		}
+	}
+
 	// Group messages have a different chunk layout
 	if ToType(msg.ToType) == ToRoom || ToType(msg.ToType) == ToGroup {
 		return

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -57,6 +57,13 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 			// Ensure peer keys are available before attempting decryption
 			lc.ensurePeerKeyForMessage(context.Background(), msg)
 
+			// If we receive an encrypted group message, clear its noE2EE cache
+			// so future sends will attempt E2EE again.
+			if (ToType(msg.ToType) == ToRoom || ToType(msg.ToType) == ToGroup) && lc.isGroupNoE2EE(portalIDStr) {
+				lc.UserLogin.Bridge.Log.Info().Str("chat_mid", portalIDStr).Msg("Received encrypted group message, clearing noE2EE cache")
+				lc.clearGroupNoE2EE(portalIDStr)
+			}
+
 			if ToType(msg.ToType) == ToRoom || ToType(msg.ToType) == ToGroup {
 				// Group Decryption
 				if len(msg.Chunks) >= 5 {

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -28,31 +28,54 @@ import (
 )
 
 func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.MatrixMessage) (*bridgev2.MatrixMessageResponse, error) {
-	if lc.E2EE == nil {
-		return nil, fmt.Errorf("E2EE not initialized; cannot send")
-	}
-
 	client := line.NewClient(lc.AccessToken)
 	portalMid := string(msg.Portal.ID)
 	fromMid := lc.midOrFallback()
 
+	lowerPortalID := strings.ToLower(portalMid)
+	isGroup := strings.HasPrefix(lowerPortalID, "c") || strings.HasPrefix(lowerPortalID, "r")
+
+	// Determine whether we need to send as plain text (peer/group has Letter Sealing off).
+	plainText := false
+	if lc.E2EE == nil {
+		plainText = true
+		lc.UserLogin.Bridge.Log.Warn().Msg("E2EE not initialized, sending as plain text")
+	} else if isGroup {
+		if lc.isGroupNoE2EE(portalMid) {
+			plainText = true
+		}
+	} else {
+		// 1:1 — probe peer key to determine E2EE support
+		_, _, errPeer := lc.ensurePeerKey(ctx, portalMid)
+		if errPeer != nil && line.IsNoUsableE2EEPublicKey(errPeer) {
+			plainText = true
+		} else if errPeer != nil {
+			return nil, fmt.Errorf("failed to get peer key: %w", errPeer)
+		}
+	}
+
 	var chunks []string
 	var err error
 	contentType := int(ContentText)
-	contentMetadata := map[string]string{
-		"e2eeVersion": "2",
+	contentMetadata := map[string]string{}
+	if !plainText {
+		contentMetadata["e2eeVersion"] = "2"
 	}
 
+	// For plain text, we set lineMsg.Text directly; payload is used only for E2EE.
 	var payload []byte
+	var plainTextBody string // used when plainText == true for text messages
 
 	switch msg.Content.MsgType {
 	case event.MsgText:
 		contentType = int(ContentText)
-		// For groups, EncryptGroupMessage wraps in {"text": ...}
-		// For 1:1, we need JSON for EncryptMessageV2Raw
-		payload, err = json.Marshal(map[string]string{"text": msg.Content.Body})
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal text payload: %w", err)
+		if plainText {
+			plainTextBody = msg.Content.Body
+		} else {
+			payload, err = json.Marshal(map[string]string{"text": msg.Content.Body})
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal text payload: %w", err)
+			}
 		}
 
 	case event.MsgImage:
@@ -72,47 +95,58 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 			extension = "png"
 		}
 
-		encryptedData, keyMaterialB64, err := lc.encryptFileData(data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encrypt image data: %w", err)
+		var uploadData []byte
+		var keyMaterialB64 string
+
+		if plainText {
+			// Upload raw (unencrypted) data
+			uploadData = data
+		} else {
+			uploadData, keyMaterialB64, err = lc.encryptFileData(data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt image data: %w", err)
+			}
 		}
 
-		oid, err := client.UploadOBS(encryptedData)
+		oid, err := client.UploadOBS(uploadData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to upload encrypted image to OBS: %w", err)
+			return nil, fmt.Errorf("failed to upload image to OBS: %w", err)
 		}
 
 		thumbnailData, thumbWidth, thumbHeight, err := generateThumbnail(data)
 		if err != nil {
 			lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to generate thumbnail, continuing without it")
 		} else {
-			keyMaterial, _ := base64.StdEncoding.DecodeString(keyMaterialB64)
+			var thumbToUpload []byte
+			if plainText {
+				thumbToUpload = thumbnailData
+			} else {
+				keyMaterial, _ := base64.StdEncoding.DecodeString(keyMaterialB64)
 
-			// Derive keys using HKDF
-			kdf := hkdf.New(sha256.New, keyMaterial, nil, []byte("FileEncryption"))
-			derived := make([]byte, 76)
-			io.ReadFull(kdf, derived)
+				kdf := hkdf.New(sha256.New, keyMaterial, nil, []byte("FileEncryption"))
+				derived := make([]byte, 76)
+				io.ReadFull(kdf, derived)
 
-			encKey := derived[0:32]
-			macKey := derived[32:64]
-			nonce := derived[64:76]
+				encKey := derived[0:32]
+				macKey := derived[32:64]
+				nonce := derived[64:76]
 
-			counter := make([]byte, 16)
-			copy(counter, nonce)
+				counter := make([]byte, 16)
+				copy(counter, nonce)
 
-			block, _ := aes.NewCipher(encKey)
-			stream := cipher.NewCTR(block, counter)
+				block, _ := aes.NewCipher(encKey)
+				stream := cipher.NewCTR(block, counter)
 
-			encryptedThumb := make([]byte, len(thumbnailData))
-			stream.XORKeyStream(encryptedThumb, thumbnailData)
+				encryptedThumb := make([]byte, len(thumbnailData))
+				stream.XORKeyStream(encryptedThumb, thumbnailData)
 
-			h := hmac.New(sha256.New, macKey)
-			h.Write(encryptedThumb)
-			encryptedThumbWithHMAC := append(encryptedThumb, h.Sum(nil)...)
+				h := hmac.New(sha256.New, macKey)
+				h.Write(encryptedThumb)
+				thumbToUpload = append(encryptedThumb, h.Sum(nil)...)
+			}
 
-			// Upload preview
 			previewOID := fmt.Sprintf("%s__ud-preview", oid)
-			if err := client.UploadOBSWithOID(encryptedThumbWithHMAC, previewOID); err != nil {
+			if err := client.UploadOBSWithOID(thumbToUpload, previewOID); err != nil {
 				lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to upload preview, continuing without it")
 			} else {
 				mediaThumbInfo := map[string]interface{}{
@@ -132,17 +166,16 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 			}
 		}
 
-		// metadata
 		contentType = int(ContentImage)
 		contentMetadata["OID"] = oid
-		contentMetadata["SID"] = "emi" // source ID for LINE images
-		contentMetadata["FILE_SIZE"] = fmt.Sprintf("%d", len(encryptedData))
+		contentMetadata["SID"] = "emi"
+		contentMetadata["FILE_SIZE"] = fmt.Sprintf("%d", len(uploadData))
 		contentMetadata["contentType"] = fmt.Sprintf("%d", ContentImage)
 
-		// Add encryption key material to metadata (ENC_KM)
-		contentMetadata["ENC_KM"] = keyMaterialB64
+		if !plainText {
+			contentMetadata["ENC_KM"] = keyMaterialB64
+		}
 
-		// Add file name
 		fileName := msg.Content.Body
 		if fileName == "" {
 			if isGif {
@@ -153,18 +186,14 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		}
 		contentMetadata["FILE_NAME"] = fileName
 
-		// Add MEDIA_CONTENT_INFO for proper display
 		mediaContentInfo := map[string]interface{}{
 			"category":  "original",
-			"fileSize":  len(encryptedData),
+			"fileSize":  len(uploadData),
 			"extension": extension,
 		}
-
-		// Add animated flag for GIFs
 		if isAnimated {
 			mediaContentInfo["animated"] = true
 		}
-
 		if mediaInfoJSON, err := json.Marshal(mediaContentInfo); err == nil {
 			contentMetadata["MEDIA_CONTENT_INFO"] = string(mediaInfoJSON)
 		}
@@ -172,29 +201,32 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		payload = []byte("{}")
 
 	case event.MsgFile:
-		// Generic files
 		data, err := lc.UserLogin.Bridge.Bot.DownloadMedia(ctx, msg.Content.URL, msg.Content.File)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download file from matrix: %w", err)
 		}
 
-		// Encrypt the file data
-		encryptedData, keyMaterialB64, err := lc.encryptFileData(data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encrypt file data: %w", err)
+		var uploadData []byte
+		var keyMaterialB64 string
+
+		if plainText {
+			uploadData = data
+		} else {
+			uploadData, keyMaterialB64, err = lc.encryptFileData(data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt file data: %w", err)
+			}
 		}
 
-		// Upload encrypted file to LINE OBS with emf SID
-		oid, err := client.UploadOBSWithSID(encryptedData, "emf")
+		oid, err := client.UploadOBSWithSID(uploadData, "emf")
 		if err != nil {
-			return nil, fmt.Errorf("failed to upload encrypted file to OBS: %w", err)
+			return nil, fmt.Errorf("failed to upload file to OBS: %w", err)
 		}
 
-		// Prepare Metadata
 		contentType = int(ContentFile)
 		contentMetadata["OID"] = oid
-		contentMetadata["SID"] = "emf"                              // File SID
-		contentMetadata["FILE_SIZE"] = fmt.Sprintf("%d", len(data)) // Original unencrypted size
+		contentMetadata["SID"] = "emf"
+		contentMetadata["FILE_SIZE"] = fmt.Sprintf("%d", len(data))
 		contentMetadata["contentType"] = fmt.Sprintf("%d", ContentFile)
 
 		fileName := msg.Content.Body
@@ -203,20 +235,24 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		}
 		contentMetadata["FILE_NAME"] = fileName
 
-		// For files, encryption key and filename go in the E2EE encrypted payload
-		filePayload := map[string]string{
-			"keyMaterial": keyMaterialB64,
-			"fileName":    fileName,
+		if plainText {
+			payload = []byte("{}")
+		} else {
+			filePayload := map[string]string{
+				"keyMaterial": keyMaterialB64,
+				"fileName":    fileName,
+			}
+			payloadBytes, _ := json.Marshal(filePayload)
+			payload = payloadBytes
 		}
-		payloadBytes, _ := json.Marshal(filePayload)
-		payload = payloadBytes
 
 		lc.UserLogin.Bridge.Log.Info().
 			Str("oid", oid).
 			Str("file_name", fileName).
-			Int("encrypted_size", len(encryptedData)).
+			Bool("plain_text", plainText).
+			Int("upload_size", len(uploadData)).
 			Int("original_size", len(data)).
-			Msg("Prepared E2EE file message")
+			Msg("Prepared file message")
 
 	case event.MsgVideo:
 		data, err := lc.UserLogin.Bridge.Bot.DownloadMedia(ctx, msg.Content.URL, msg.Content.File)
@@ -224,26 +260,35 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 			return nil, fmt.Errorf("failed to download video from matrix: %w", err)
 		}
 
-		encryptedData, keyMaterialB64, err := lc.encryptVideoData(data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encrypt video data: %w", err)
+		var uploadData []byte
+		var keyMaterialB64 string
+
+		if plainText {
+			uploadData = data
+		} else {
+			uploadData, keyMaterialB64, err = lc.encryptVideoData(data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt video data: %w", err)
+			}
 		}
 
-		oid, err := client.UploadOBSWithSID(encryptedData, "emv")
+		oid, err := client.UploadOBSWithSID(uploadData, "emv")
 		if err != nil {
-			return nil, fmt.Errorf("failed to upload encrypted video to OBS: %w", err)
+			return nil, fmt.Errorf("failed to upload video to OBS: %w", err)
 		}
 
-		chunkHashes := generateChunkHashes(encryptedData[:len(encryptedData)-32]) // Exclude HMAC
-		if len(chunkHashes) > 0 {
-			hashOID := fmt.Sprintf("%s__ud-hash", oid)
-			if err := client.UploadOBSWithOIDAndSID(chunkHashes, hashOID, "emv"); err != nil {
-				lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to upload video hash, continuing without it")
-			} else {
-				lc.UserLogin.Bridge.Log.Info().
-					Str("hash_oid", hashOID).
-					Int("hash_size", len(chunkHashes)).
-					Msg("Uploaded video chunk hashes")
+		if !plainText {
+			chunkHashes := generateChunkHashes(uploadData[:len(uploadData)-32])
+			if len(chunkHashes) > 0 {
+				hashOID := fmt.Sprintf("%s__ud-hash", oid)
+				if err := client.UploadOBSWithOIDAndSID(chunkHashes, hashOID, "emv"); err != nil {
+					lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to upload video hash, continuing without it")
+				} else {
+					lc.UserLogin.Bridge.Log.Info().
+						Str("hash_oid", hashOID).
+						Int("hash_size", len(chunkHashes)).
+						Msg("Uploaded video chunk hashes")
+				}
 			}
 		}
 
@@ -259,30 +304,35 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		}
 
 		if len(thumbnailData) > 0 {
-			keyMaterial, _ := base64.StdEncoding.DecodeString(keyMaterialB64)
-			kdf := hkdf.New(sha256.New, keyMaterial, nil, []byte("FileEncryption"))
-			derived := make([]byte, 76)
-			io.ReadFull(kdf, derived)
+			var thumbToUpload []byte
+			if plainText {
+				thumbToUpload = thumbnailData
+			} else {
+				keyMaterial, _ := base64.StdEncoding.DecodeString(keyMaterialB64)
+				kdf := hkdf.New(sha256.New, keyMaterial, nil, []byte("FileEncryption"))
+				derived := make([]byte, 76)
+				io.ReadFull(kdf, derived)
 
-			encKey := derived[0:32]
-			macKey := derived[32:64]
-			nonce := derived[64:76]
+				encKey := derived[0:32]
+				macKey := derived[32:64]
+				nonce := derived[64:76]
 
-			counter := make([]byte, 16)
-			copy(counter, nonce)
+				counter := make([]byte, 16)
+				copy(counter, nonce)
 
-			block, _ := aes.NewCipher(encKey)
-			stream := cipher.NewCTR(block, counter)
+				block, _ := aes.NewCipher(encKey)
+				stream := cipher.NewCTR(block, counter)
 
-			encryptedThumb := make([]byte, len(thumbnailData))
-			stream.XORKeyStream(encryptedThumb, thumbnailData)
+				encryptedThumb := make([]byte, len(thumbnailData))
+				stream.XORKeyStream(encryptedThumb, thumbnailData)
 
-			h := hmac.New(sha256.New, macKey)
-			h.Write(encryptedThumb)
-			encryptedThumbWithHMAC := append(encryptedThumb, h.Sum(nil)...)
+				h := hmac.New(sha256.New, macKey)
+				h.Write(encryptedThumb)
+				thumbToUpload = append(encryptedThumb, h.Sum(nil)...)
+			}
 
 			previewOID := fmt.Sprintf("%s__ud-preview", oid)
-			if err := client.UploadOBSWithOIDAndSID(encryptedThumbWithHMAC, previewOID, "emv"); err != nil {
+			if err := client.UploadOBSWithOIDAndSID(thumbToUpload, previewOID, "emv"); err != nil {
 				lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to upload video preview, continuing without it")
 			} else {
 				mediaThumbInfo := map[string]interface{}{
@@ -295,7 +345,7 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 
 				lc.UserLogin.Bridge.Log.Info().
 					Str("preview_oid", previewOID).
-					Int("preview_size", len(encryptedThumbWithHMAC)).
+					Int("preview_size", len(thumbToUpload)).
 					Int("thumb_width", thumbWidth).
 					Int("thumb_height", thumbHeight).
 					Msg("Uploaded video preview placeholder")
@@ -304,66 +354,82 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 
 		contentType = int(ContentVideo)
 		contentMetadata["OID"] = oid
-		contentMetadata["SID"] = "emv"                              // Video SID
-		contentMetadata["FILE_SIZE"] = fmt.Sprintf("%d", len(data)) // Original unencrypted size
+		contentMetadata["SID"] = "emv"
+		contentMetadata["FILE_SIZE"] = fmt.Sprintf("%d", len(data))
 		contentMetadata["contentType"] = fmt.Sprintf("%d", ContentVideo)
-		contentMetadata["ENC_KM"] = keyMaterialB64 // Required for OBS access
 
-		// Add duration if available (in milliseconds)
+		if !plainText {
+			contentMetadata["ENC_KM"] = keyMaterialB64
+		}
+
 		if msg.Content.Info.Duration > 0 {
 			contentMetadata["DURATION"] = fmt.Sprintf("%d", msg.Content.Info.Duration)
 		}
 
-		//Empty payload like images
 		payload = []byte("{}")
 
 		lc.UserLogin.Bridge.Log.Info().
 			Str("oid", oid).
-			Str("enc_km", keyMaterialB64[:20]+"...").
-			Int("encrypted_size", len(encryptedData)).
-			Msg("Prepared E2EE video message")
+			Bool("plain_text", plainText).
+			Int("upload_size", len(uploadData)).
+			Msg("Prepared video message")
 
 	default:
 		return nil, fmt.Errorf("message type %s not implemented", msg.Content.MsgType)
 	}
 
-	lowerPortalID := strings.ToLower(portalMid)
-	isGroup := strings.HasPrefix(lowerPortalID, "c") || strings.HasPrefix(lowerPortalID, "r")
-
-	if isGroup {
-		if errFetch := lc.fetchAndUnwrapGroupKey(ctx, portalMid, 0); errFetch != nil {
-			lc.UserLogin.Bridge.Log.Debug().Err(errFetch).Str("chat_mid", portalMid).Msg("fetchAndUnwrapGroupKey before encrypt failed")
-		}
-		if contentType != int(ContentText) {
-			chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
-		} else {
-			chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
-		}
-		if err != nil {
-			if errFetch := lc.fetchAndUnwrapGroupKey(ctx, portalMid, 0); errFetch == nil {
-				if contentType != int(ContentText) {
-					chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
-				} else {
-					chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
+	// Encryption phase — skip entirely for plain text
+	if !plainText {
+		if isGroup {
+			if errFetch := lc.fetchAndUnwrapGroupKey(ctx, portalMid, 0); errFetch != nil {
+				lc.UserLogin.Bridge.Log.Debug().Err(errFetch).Str("chat_mid", portalMid).Msg("fetchAndUnwrapGroupKey before encrypt failed")
+			}
+			if contentType != int(ContentText) {
+				chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
+			} else {
+				chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
+			}
+			if err != nil {
+				if errFetch := lc.fetchAndUnwrapGroupKey(ctx, portalMid, 0); errFetch == nil {
+					if contentType != int(ContentText) {
+						chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
+					} else {
+						chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
+					}
+				} else if line.IsNoUsableE2EEGroupKey(errFetch) || line.IsNoUsableE2EEGroupKey(err) {
+					// Group has no E2EE keys — fall back to plain text
+					lc.markGroupNoE2EE(portalMid)
+					lc.UserLogin.Bridge.Log.Info().Str("chat_mid", portalMid).Msg("Group has no E2EE keys, falling back to plain text")
+					plainText = true
+					chunks = nil
+					err = nil
+					delete(contentMetadata, "e2eeVersion")
+					if contentType == int(ContentText) {
+						plainTextBody = msg.Content.Body
+					}
 				}
 			}
-		}
-	} else {
-		// 1-1 Encryption
-		myRaw, myKeyID, errKey := lc.E2EE.MyKeyIDs()
-		if errKey != nil {
-			return nil, fmt.Errorf("missing own E2EE key: %w", errKey)
-		}
-		peerRaw, peerPub, errPeer := lc.ensurePeerKey(ctx, portalMid)
-		if errPeer != nil {
-			return nil, fmt.Errorf("failed to get peer key: %w", errPeer)
+		} else {
+			// 1-1 Encryption (peer key already fetched above)
+			myRaw, myKeyID, errKey := lc.E2EE.MyKeyIDs()
+			if errKey != nil {
+				return nil, fmt.Errorf("missing own E2EE key: %w", errKey)
+			}
+			peerRaw, peerPub, errPeer := lc.ensurePeerKey(ctx, portalMid)
+			if errPeer != nil {
+				return nil, fmt.Errorf("failed to get peer key: %w", errPeer)
+			}
+
+			chunks, err = lc.E2EE.EncryptMessageV2Raw(portalMid, fromMid, myKeyID, peerPub, myRaw, peerRaw, contentType, payload)
 		}
 
-		chunks, err = lc.E2EE.EncryptMessageV2Raw(portalMid, fromMid, myKeyID, peerPub, myRaw, peerRaw, contentType, payload)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt failed: %w", err)
+		}
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("encrypt failed: %w", err)
+	if plainText {
+		lc.UserLogin.Bridge.Log.Info().Str("portal", portalMid).Int("content_type", contentType).Msg("Sending plain text message (no E2EE)")
 	}
 
 	now := time.Now().UnixMilli()
@@ -375,9 +441,14 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		SessionID:       0,
 		CreatedTime:     json.Number(strconv.FormatInt(now, 10)),
 		ContentType:     contentType,
-		HasContent:      contentType != int(ContentText), // True for images
+		HasContent:      contentType != int(ContentText),
 		ContentMetadata: contentMetadata,
-		Chunks:          chunks,
+	}
+
+	if plainText {
+		lineMsg.Text = plainTextBody
+	} else {
+		lineMsg.Chunks = chunks
 	}
 
 	var relatedMsg *database.Message

--- a/pkg/line/errors.go
+++ b/pkg/line/errors.go
@@ -1,0 +1,84 @@
+package line
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrNoUsableE2EEPublicKey = errors.New("no usable E2EE public key")
+	ErrNoUsableE2EEGroupKey  = errors.New("no usable E2EE group key")
+)
+
+// IsNoUsableE2EEPublicKey returns true when a peer has Letter Sealing disabled
+// (negotiateE2EEPublicKey returns empty allowedTypes / specVersion -1, or no key data).
+func IsNoUsableE2EEPublicKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrNoUsableE2EEPublicKey) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "missing fields (pub=false keyID=-1") ||
+		strings.Contains(msg, "missing fields (pub=false keyID=0") ||
+		(strings.Contains(msg, "\"allowedTypes\":[]") && strings.Contains(msg, "\"specVersion\":-1"))
+}
+
+// IsNoUsableE2EEGroupKey returns true when a group has no shared E2EE key
+// (at least one member has Letter Sealing disabled).
+func IsNoUsableE2EEGroupKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrNoUsableE2EEGroupKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "no group key found") ||
+		strings.Contains(msg, "no group shared key returned") {
+		return true
+	}
+	// Detect TalkException codes in raw API error strings (HTTP 400 with code 10051).
+	// Code 5 "not found" = no group shared key; Code 98 = member has LS off;
+	// Code 1 "Authentication Failed" from getE2EEGroupSharedKey also indicates no key access.
+	if strings.Contains(msg, "\"code\":10051") && strings.Contains(msg, "talkexception") {
+		if strings.Contains(msg, "\"code\":5") || strings.Contains(msg, "\"code\":98") || strings.Contains(msg, "\"code\":1") {
+			return true
+		}
+	}
+	return false
+}
+
+type talkExceptionData struct {
+	Name    string `json:"name"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+	Reason  string `json:"reason"`
+}
+
+func isNoUsableE2EEGroupKeyTalkException(message string, data talkExceptionData) bool {
+	if !strings.EqualFold(message, "RESPONSE_ERROR") || !strings.EqualFold(data.Name, "TalkException") {
+		return false
+	}
+	// Error 5 "not found" = no group shared key exists
+	// Error 98 "member settings off" = at least one member has LS disabled
+	return (data.Code == 5 && strings.EqualFold(data.Reason, "not found")) ||
+		(data.Code == 98 && strings.Contains(strings.ToLower(data.Reason), "member settings off"))
+}
+
+func parseTalkExceptionData(raw json.RawMessage) talkExceptionData {
+	var data talkExceptionData
+	_ = json.Unmarshal(raw, &data)
+	return data
+}
+
+func parseE2EEGroupKeyError(method, message string, rawData json.RawMessage) error {
+	talk := parseTalkExceptionData(rawData)
+	if isNoUsableE2EEGroupKeyTalkException(message, talk) {
+		return fmt.Errorf("%w: %s", ErrNoUsableE2EEGroupKey, talk.Reason)
+	}
+	return fmt.Errorf("%s failed: %s", method, message)
+}

--- a/pkg/line/methods.go
+++ b/pkg/line/methods.go
@@ -119,17 +119,21 @@ func (c *Client) GetE2EEGroupSharedKey(chatMid string, groupKeyID int) (*E2EEGro
 		return nil, err
 	}
 	var wrapper struct {
-		Code    int                `json:"code"`
-		Message string             `json:"message"`
-		Data    E2EEGroupSharedKey `json:"data"`
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(resp, &wrapper); err != nil {
 		return nil, err
 	}
 	if wrapper.Code != 0 {
-		return nil, fmt.Errorf("getE2EEGroupSharedKey failed: %s", wrapper.Message)
+		return nil, parseE2EEGroupKeyError("getE2EEGroupSharedKey", wrapper.Message, wrapper.Data)
 	}
-	return &wrapper.Data, nil
+	var data E2EEGroupSharedKey
+	if err := json.Unmarshal(wrapper.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
 }
 
 func (c *Client) GetLastE2EEGroupSharedKey(chatMid string) (*E2EEGroupSharedKey, error) {
@@ -138,17 +142,21 @@ func (c *Client) GetLastE2EEGroupSharedKey(chatMid string) (*E2EEGroupSharedKey,
 		return nil, err
 	}
 	var wrapper struct {
-		Code    int                `json:"code"`
-		Message string             `json:"message"`
-		Data    E2EEGroupSharedKey `json:"data"`
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(resp, &wrapper); err != nil {
 		return nil, err
 	}
 	if wrapper.Code != 0 {
-		return nil, fmt.Errorf("getLastE2EEGroupSharedKey failed: %s", wrapper.Message)
+		return nil, parseE2EEGroupKeyError("getLastE2EEGroupSharedKey", wrapper.Message, wrapper.Data)
 	}
-	return &wrapper.Data, nil
+	var data E2EEGroupSharedKey
+	if err := json.Unmarshal(wrapper.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
 }
 
 // NegotiateE2EEPublicKey fetches (or renews) the public key of the person you're talking to (E2EE).
@@ -279,7 +287,7 @@ func parseE2EEPublicKey(rawData []byte) (*E2EEPublicKey, error) {
 		keyID = findInt64(data)
 	}
 	if pub == "" || keyID == 0 {
-		return nil, fmt.Errorf("missing fields (pub=%t keyID=%d raw=%s)", pub != "", keyID, string(rawData))
+		return nil, fmt.Errorf("%w: missing fields (pub=%t keyID=%d raw=%s)", ErrNoUsableE2EEPublicKey, pub != "", keyID, string(rawData))
 	}
 
 	return &E2EEPublicKey{


### PR DESCRIPTION
## Summary
- When a peer or group has Letter Sealing disabled, fall back to sending messages as plain text instead of failing with an encryption error — matching LINE Chrome extension behavior
- Cache negative E2EE negotiation results with a 1-hour TTL and auto-invalidate when encrypted messages arrive from previously-off peers
- Detect TalkException codes 1/5/98 as group key unavailability and skip destructive token recovery for these errors

## Test plan
- [x] Send text message from bridge (LSON) to LSOFF user → arrives as readable text
- [x] Send text in group created by LSOFF user → arrives as readable text
- [x] Send text in group created by LSON user → arrives as readable text
- [x] Receive messages from LSOFF user in 1:1 and groups → bridged correctly
- [x] Verify LSON→LSON messaging still works (no regression)
- [ ] Test media (image/video/file) to LSOFF user
- Test existing chat with LSOFF after he becomes LSON doesn't break
  - I'll have to do this one later as I still need the account with LSOFF for the login and other way around cases

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## How it works

### Send path

```mermaid
graph TD
    A["HandleMatrixMessage()"] --> B{Is group?}

    B -->|No| C["ensurePeerKey(portalMid)"]
    C --> D{ErrNoUsableE2EEPublicKey?}
    D -->|Yes| PT["plainText = true"]
    D -->|No| E2["plainText = false"]

    B -->|Yes| G{isGroupNoE2EE cached?}
    G -->|Yes| PT
    G -->|No| E2

    PT --> PREP["Prepare payload"]
    E2 --> PREP

    PREP --> CHK{plainText?}

    CHK -->|"Yes · text"| PLAIN_TXT["lineMsg.Text = body
    No chunks
    No e2eeVersion"]

    CHK -->|"Yes · media"| PLAIN_MED["Upload raw data to OBS
    No encryption
    No ENC_KM"]

    CHK -->|"No · text"| ENC["Encrypt via E2EE manager"]
    CHK -->|"No · media"| ENC_MED["encryptFileData()
    Upload encrypted to OBS
    Set ENC_KM, e2eeVersion=2"]

    ENC --> GRP{Group encrypt failed?}
    GRP -->|"IsNoUsableE2EEGroupKey"| FALLBACK["markGroupNoE2EE()
    Fall back to plain text"]
    FALLBACK --> PLAIN_TXT
    GRP -->|No| CHUNKS["lineMsg.Chunks = encrypted"]

    ENC_MED --> CHUNKS
    PLAIN_MED --> PLAIN_TXT

    PLAIN_TXT --> SEND["SendMessage()"]
    CHUNKS --> SEND

    style PT fill:#f9e4b7,stroke:#e6a817
    style PLAIN_TXT fill:#f9e4b7,stroke:#e6a817
    style PLAIN_MED fill:#f9e4b7,stroke:#e6a817
    style FALLBACK fill:#f9e4b7,stroke:#e6a817
```

### Cache invalidation

```mermaid
graph TD
    subgraph "1:1 peers"
        A["ensurePeerKey()
        → peer has LS off"] --> B["Cache
        noE2EE = true
        checkedAt = now"]
        B --> C{"Time since
        checkedAt?"}
        C -->|"< 1 hr"| D["Return cached error
        → send plain text"]
        C -->|"> 1 hr (TTL expired)"| E["Re-negotiate
        with LINE API"]
        F["Receive encrypted msg
        from cached-off peer"] --> G["Delete cache entry"]
        G --> E
    end

    subgraph "Groups"
        H["fetchAndUnwrapGroupKey()
        → TalkException 1/5/98"] --> I["markGroupNoE2EE()"]
        I --> J{"Time since
        marked?"}
        J -->|"< 1 hr"| K["Skip fetch
        → send plain text"]
        J -->|"> 1 hr"| L["Retry group
        key fetch"]
        M["Receive encrypted
        group message"] --> N["clearGroupNoE2EE()"]
        N --> L
    end

    style B fill:#f9e4b7,stroke:#e6a817
    style D fill:#f9e4b7,stroke:#e6a817
    style I fill:#f9e4b7,stroke:#e6a817
    style K fill:#f9e4b7,stroke:#e6a817
```
