### PR TITLE
fix: retry OBS downloads on 404 and handle media failures gracefully

### DIFF
--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -188,13 +188,24 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 					}
 
 					if err != nil {
-						lc.UserLogin.Bridge.Log.Error().
+						lc.UserLogin.Bridge.Log.Warn().
 							Err(err).
 							Str("oid", oid).
 							Str("msg_id", data.ID).
 							Bool("plain_media", isPlainMedia).
-							Msg("Failed to download image from OBS")
-						return nil, fmt.Errorf("failed to download image from OBS: %w", err)
+							Msg("Failed to download image from OBS, sending placeholder")
+						return &bridgev2.ConvertedMessage{
+							Parts: []*bridgev2.ConvertedMessagePart{
+								{
+									Type: event.EventMessage,
+									Content: &event.MessageEventContent{
+										MsgType:   event.MsgNotice,
+										Body:      "[Image unavailable — LINE media expired before it could be bridged]",
+										RelatesTo: replyRelatesTo,
+									},
+								},
+							},
+						}, nil
 					}
 
 					// Decrypt image if it has keyMaterial (E2EE)
@@ -280,13 +291,24 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 					}
 
 					if err != nil {
-						lc.UserLogin.Bridge.Log.Error().
+						lc.UserLogin.Bridge.Log.Warn().
 							Err(err).
 							Str("oid", oid).
 							Str("msg_id", data.ID).
 							Bool("plain_media", isPlainMedia).
-							Msg("Failed to download video from OBS")
-						return nil, fmt.Errorf("failed to download video from OBS: %w", err)
+							Msg("Failed to download video from OBS, sending placeholder")
+						return &bridgev2.ConvertedMessage{
+							Parts: []*bridgev2.ConvertedMessagePart{
+								{
+									Type: event.EventMessage,
+									Content: &event.MessageEventContent{
+										MsgType:   event.MsgNotice,
+										Body:      "[Video unavailable — LINE media expired before it could be bridged]",
+										RelatesTo: replyRelatesTo,
+									},
+								},
+							},
+						}, nil
 					}
 
 					if decryptedBody != "" && strings.Contains(decryptedBody, "keyMaterial") {
@@ -421,12 +443,23 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 					}
 					fileData, err := client.DownloadOBSWithSID(oid, data.ID, sid)
 					if err != nil {
-						lc.UserLogin.Bridge.Log.Error().
+						lc.UserLogin.Bridge.Log.Warn().
 							Err(err).
 							Str("oid", oid).
 							Bool("plain_media", isPlainMedia).
-							Msg("Failed to download file from OBS")
-						return nil, fmt.Errorf("failed to download file from OBS: %w", err)
+							Msg("Failed to download file from OBS, sending placeholder")
+						return &bridgev2.ConvertedMessage{
+							Parts: []*bridgev2.ConvertedMessagePart{
+								{
+									Type: event.EventMessage,
+									Content: &event.MessageEventContent{
+										MsgType:   event.MsgNotice,
+										Body:      "[File unavailable — LINE media expired before it could be bridged]",
+										RelatesTo: replyRelatesTo,
+									},
+								},
+							},
+						}, nil
 					}
 
 					// Try to decrypt using keyMaterial from encrypted payload

--- a/pkg/line/client.go
+++ b/pkg/line/client.go
@@ -664,7 +664,7 @@ func (c *Client) DownloadOBSWithSID(oid string, messageID string, sid string) ([
 			return nil, fmt.Errorf("OBS download request failed: %w", err)
 		}
 
-		if resp.StatusCode == 202 && attempt < maxRetries {
+		if (resp.StatusCode == 202 || resp.StatusCode == 404) && attempt < maxRetries {
 			resp.Body.Close()
 			time.Sleep(2 * time.Second)
 			// Rebuild request for retry


### PR DESCRIPTION
## Summary

- Retry OBS media downloads on 404 responses (LINE returns 404 transiently for recently uploaded media)
- Gracefully handle media download failures instead of breaking the entire message flow

Please see: https://github.com/clins1994/matrix-line-messenger/pull/2 for more information

Closes #71

## Problem (before)

```mermaid
flowchart TD
    A[Bundle of photos sent on LINE] --> B[Bridge receives multiple messages]
    B --> C[Download media from OBS for each]
    
    C --> D{OBS response?}
    D -->|200 OK| E[Media bridged successfully]
    D -->|202 Processing| F[Retry up to 5x with 2s delay]
    D -->|404 Not Found| G[Immediate hard error]
    
    G --> H[fmt.Errorf returned]
    H --> I[Entire message dropped]
    I --> J[User never sees the photo on Beeper]
    
    F -->|Eventually 200| E
    F -->|Still 202| H
    
    style G fill:#e76f51,color:#fff
    style I fill:#e76f51,color:#fff
    style J fill:#e76f51,color:#fff
```

**Root cause:** LINE's OBS returns transient 404s for recently uploaded media (race condition between upload confirmation and storage propagation). The bridge treated 404 as a permanent failure. When any single download in a bundle failed, the entire message was dropped with no trace on Beeper.

## Solution (after)

```mermaid
flowchart TD
    A[Bundle of photos sent on LINE] --> B[Bridge receives multiple messages]
    B --> C[Download media from OBS for each]
    
    C --> D{OBS response?}
    D -->|200 OK| E[Media bridged successfully]
    D -->|202 Processing| F[Retry up to 5x with 2s delay]
    D -->|404 Not Found| F
    
    F -->|Eventually 200| E
    F -->|Still failing| G[Send placeholder message]
    G --> H["[Image unavailable — LINE media expired before it could be bridged]"]
    
    H --> I[User sees the placeholder on Beeper]
    E --> J[User sees the photo on Beeper]
    
    style E fill:#2d6a4f,color:#fff
    style J fill:#2d6a4f,color:#fff
    style I fill:#e9c46a,color:#000
```

**Two improvements:**
1. **404 retry** — transient 404s are retried alongside 202s (up to 5x with 2s delay), giving OBS time to propagate
2. **Graceful degradation** — if download still fails after retries, a placeholder notice is sent instead of silently dropping the message

## Test plan

- [x] Send a bundle of photos in a LINE chat and verify all are received on the bridge side
- [x] Verify single image/video/file downloads still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)