### PR TITLE
fix: update contact display names in real time

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -29,7 +29,7 @@ type LineClient struct {
 	sentReqSeqs map[int]time.Time
 
 	noE2EEGroups map[string]time.Time // chatMid -> when group E2EE failure was cached
-	contactCache map[string]line.Contact
+	contactCache map[string]cachedContact
 }
 
 type peerKeyInfo struct {
@@ -37,6 +37,13 @@ type peerKeyInfo struct {
 	pub       string
 	noE2EE    bool      // true if peer has Letter Sealing off
 	checkedAt time.Time // when noE2EE was last verified
+}
+
+const contactCacheTTL = 1 * time.Hour
+
+type cachedContact struct {
+	line.Contact
+	cachedAt time.Time
 }
 
 var _ bridgev2.NetworkAPI = (*LineClient)(nil)
@@ -97,7 +104,7 @@ func (lc *LineClient) Connect(ctx context.Context) {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
 	if lc.contactCache == nil {
-		lc.contactCache = make(map[string]line.Contact)
+		lc.contactCache = make(map[string]cachedContact)
 	}
 	lc.reqSeqMu.Lock()
 	if lc.sentReqSeqs == nil {

--- a/pkg/connector/consts.go
+++ b/pkg/connector/consts.go
@@ -12,6 +12,7 @@ const (
 	OpSendMessage    OperationType = 25
 	OpReceiveMessage OperationType = 26
 	OpReaction       OperationType = 140
+	OpContactUpdate  OperationType = 49
 )
 
 // ContentType values for LINE messages.

--- a/pkg/connector/sync.go
+++ b/pkg/connector/sync.go
@@ -284,8 +284,8 @@ func (lc *LineClient) generateNameFromMembers(members map[string]bool) string {
 		if mid == string(lc.UserLogin.ID) || mid == lc.Mid || strings.HasPrefix(mid, "c") || strings.HasPrefix(mid, "r") {
 			continue
 		}
-		if contact, ok := lc.contactCache[mid]; ok && contact.DisplayName != "" {
-			names = append(names, contact.DisplayName)
+		if cached, ok := lc.contactCache[mid]; ok && cached.DisplayName != "" {
+			names = append(names, cached.DisplayName)
 		}
 		count++
 		if count >= 20 {
@@ -417,6 +417,47 @@ func (lc *LineClient) pollLoop(ctx context.Context) {
 func (lc *LineClient) handleOperation(ctx context.Context, op line.Operation) {
 	// Type 25 = SEND_MESSAGE (Message sent by you from another device)
 	// Type 26 = RECEIVE_MESSAGE (Message received from another user)
+
+	if OperationType(op.Type) == OpContactUpdate {
+		mid := op.Param1
+		delete(lc.contactCache, mid)
+		contact := lc.getContact(ctx, mid)
+		name := contact.EffectiveDisplayName()
+		lc.UserLogin.Bridge.Log.Info().Str("mid", mid).Str("name", name).Msg("Contact updated")
+		ghost, err := lc.UserLogin.Bridge.GetGhostByID(ctx, makeUserID(mid))
+		if err == nil && ghost != nil {
+			ghost.UpdateInfo(ctx, &bridgev2.UserInfo{
+				Identifiers: []string{mid},
+				Name:        &name,
+			})
+		}
+		// Also update the DM portal room name
+		var avatar *bridgev2.Avatar
+		if contact.PicturePath != "" {
+			picturePath := contact.PicturePath
+			avatar = &bridgev2.Avatar{
+				ID: networkid.AvatarID(picturePath),
+				Get: func(ctx context.Context) ([]byte, error) {
+					return lc.GetAvatar(ctx, networkid.AvatarID(picturePath))
+				},
+			}
+		}
+		dmType := database.RoomTypeDM
+		portalKey := networkid.PortalKey{ID: makePortalID(mid), Receiver: lc.UserLogin.ID}
+		lc.UserLogin.Bridge.QueueRemoteEvent(lc.UserLogin, &simplevent.ChatResync{
+			EventMeta: simplevent.EventMeta{
+				Type:      bridgev2.RemoteEventChatResync,
+				PortalKey: portalKey,
+				Timestamp: time.Now(),
+			},
+			ChatInfo: &bridgev2.ChatInfo{
+				Type:   &dmType,
+				Name:   &name,
+				Avatar: avatar,
+			},
+		})
+		return
+	}
 
 	if OperationType(op.Type) == OpChatUpdate2 || OperationType(op.Type) == OpChatUpdate {
 		lc.UserLogin.Bridge.Log.Info().Str("chat_mid", op.Param1).Int("op_type", op.Type).Msg("Received chat update operation")
@@ -563,7 +604,15 @@ func (lc *LineClient) handleOperation(ctx context.Context, op line.Operation) {
 			return
 		}
 		lc.queueIncomingMessage(op.Message, op.Type)
+		return
 	}
+
+	lc.UserLogin.Bridge.Log.Debug().
+		Int("op_type", op.Type).
+		Str("param1", op.Param1).
+		Str("param2", op.Param2).
+		Str("param3", op.Param3).
+		Msg("Unhandled SSE operation")
 }
 
 func (lc *LineClient) syncSingleChat(ctx context.Context, op line.Operation) {

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"go.mau.fi/util/ptr"
 
@@ -148,7 +149,6 @@ func (lc *LineClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) 
 }
 
 func (lc *LineClient) GetUserInfo(ctx context.Context, ghost *bridgev2.Ghost) (*bridgev2.UserInfo, error) {
-	lc.UserLogin.Bridge.Log.Debug().Str("ghost_id", string(ghost.ID)).Msg("GetUserInfo called")
 	contact := lc.getContact(ctx, string(ghost.ID))
 	var avatar *bridgev2.Avatar
 	if contact.PicturePath != "" {
@@ -168,8 +168,8 @@ func (lc *LineClient) GetUserInfo(ctx context.Context, ghost *bridgev2.Ghost) (*
 }
 
 func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
-	if contact, ok := lc.contactCache[mid]; ok {
-		return contact
+	if cached, ok := lc.contactCache[mid]; ok && time.Since(cached.cachedAt) < contactCacheTTL {
+		return cached.Contact
 	}
 
 	// Use GetProfile for our own user data
@@ -184,7 +184,7 @@ func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
 		}
 		if err == nil && profile != nil {
 			contact := line.Contact{Mid: mid, DisplayName: profile.DisplayName, PicturePath: profile.PicturePath}
-			lc.contactCache[mid] = contact
+			lc.contactCache[mid] = cachedContact{Contact: contact, cachedAt: time.Now()}
 			return contact
 		}
 		return line.Contact{Mid: mid, DisplayName: mid}
@@ -200,7 +200,7 @@ func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
 	}
 	if err == nil && res != nil && res.Contacts != nil {
 		if wrapper, ok := res.Contacts[mid]; ok {
-			lc.contactCache[mid] = wrapper.Contact
+			lc.contactCache[mid] = cachedContact{Contact: wrapper.Contact, cachedAt: time.Now()}
 			return wrapper.Contact
 		}
 	}
@@ -217,7 +217,7 @@ func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
 	if err == nil && buddy != nil {
 		lc.UserLogin.Bridge.Log.Debug().Str("mid", mid).Str("display_name", buddy.DisplayName).Str("picture_path", buddy.PicturePath).Msg("Got buddy profile")
 		contact := line.Contact{Mid: mid, DisplayName: buddy.DisplayName, PicturePath: buddy.PicturePath}
-		lc.contactCache[mid] = contact
+		lc.contactCache[mid] = cachedContact{Contact: contact, cachedAt: time.Now()}
 		return contact
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary

- Handle LINE SSE operation type 49 (contact update) to refresh ghost display names and DM room names in real time
- Add 1-hour TTL to contact cache so stale names expire naturally (catches renames missed while bridge was offline)
- `getContactsV2` **does** return `displayNameOverridden` — the field was already in the struct but the cache was never invalidated

Closes #60

## Problem (before)

```mermaid
flowchart TD
    A[User renames friend on LINE] --> B[LINE sends SSE op_type=49]
    B --> C[Bridge ignores unknown op type]
    
    D[Message arrives] --> E[Framework calls GetUserInfo]
    E --> F{Contact in cache?}
    F -->|Yes| G[Return stale cached name]
    F -->|No: first time| H[Fetch from API]
    H --> I[Cache forever]
    I --> G
    
    G --> J[Ghost name never updates]
    
    style C fill:#e76f51,color:#fff
    style G fill:#e76f51,color:#fff
    style J fill:#e76f51,color:#fff
```

**Root cause:** The contact cache had no expiry and was never invalidated. SSE op 49 (contact update) was silently ignored. Once a contact was fetched, its name was frozen for the lifetime of the process.

## Solution (after)

```mermaid
flowchart TD
    A[User renames friend on LINE] --> B[LINE sends SSE op_type=49]
    B --> C[Bridge handles OpContactUpdate]
    C --> D[Delete from cache]
    D --> E[Fetch fresh contact from API]
    E --> F[Update ghost profile name]
    F --> G[Push ChatResync to update DM room name]
    G --> H[Name reflects on Beeper instantly]
    
    I[Bridge was offline during rename] --> J[Op 49 missed]
    J --> K[Next message arrives]
    K --> L[Framework calls GetUserInfo]
    L --> M{Cache entry expired? TTL: 1h}
    M -->|Yes| N[Fetch fresh from API]
    N --> O[Name updates on next message]
    M -->|No| P[Return cached name]
    
    style H fill:#2d6a4f,color:#fff
    style O fill:#2d6a4f,color:#fff
```

**Two layers:**
1. **Real-time** — op 49 fires instantly when a contact is renamed, invalidates cache, updates ghost + DM room
2. **Safety net** — 1-hour TTL on cache ensures stale names expire even if the SSE event was missed

## Test plan

- [x] Rename a friend on LINE → name updates on Beeper instantly (no message needed)
- [x] Rename, then send a message → name reflects correctly
- [x] Multiple contacts renamed → all update independently
- [x] Build passes with `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)