### PR TITLE
feat: full audio/voice message support (send and receive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Based on the [mautrix-twilio](https://github.com/mautrix/twilio) bridge
 
 ℹ️ Works with both [Letter Sealing](readme/LETTER_SEALING.md) `ON` and `OFF` accounts.
 
-- [x] Messages (Text, Images, Videos, and Files)
-- [ ] Audio / voice notes (not yet supported)
+- [x] Messages (Text, Images, Videos, Files, and Audio/Voice notes)
 - [x] Read receipts
 - [x] Reaction support (Receive ONLY)
 - [x] Replies

--- a/pkg/connector/consts.go
+++ b/pkg/connector/consts.go
@@ -21,6 +21,7 @@ const (
 	ContentText    ContentType = 0
 	ContentImage   ContentType = 1
 	ContentVideo   ContentType = 2
+	ContentAudio   ContentType = 3
 	ContentSticker ContentType = 7
 	ContentFile    ContentType = 14
 )

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -25,12 +25,15 @@ import (
 func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 	// Only process known content types; skip system messages (group created, member invited, etc.)
 	switch ContentType(msg.ContentType) {
-	case ContentText, ContentImage, ContentVideo, ContentSticker, ContentFile:
+	case ContentText, ContentImage, ContentVideo, ContentAudio, ContentSticker, ContentFile:
 		// supported — continue
 	default:
 		lc.UserLogin.Bridge.Log.Debug().
 			Int("content_type", msg.ContentType).
 			Str("msg_id", msg.ID).
+			Interface("content_metadata", msg.ContentMetadata).
+			Str("text", msg.Text).
+			Int("chunk_count", len(msg.Chunks)).
 			Msg("Skipping unsupported content type")
 		return
 	}
@@ -512,6 +515,111 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 										MimeType: mimeType,
 										Size:     len(fileData),
 									},
+									RelatesTo: replyRelatesTo,
+								},
+							},
+						},
+					}, nil
+				}
+			}
+
+			// Handle Audio
+			if ContentType(data.ContentType) == ContentAudio {
+				oid := data.ContentMetadata["OID"]
+				isPlainMedia := oid == ""
+
+				// For plain media, the audio is stored at r/talk/m/{messageID}
+				if isPlainMedia {
+					oid = data.ID
+				}
+
+				if oid != "" {
+					sid := "ema"
+					if isPlainMedia {
+						sid = "m"
+					}
+					audioData, err := client.DownloadOBSWithSID(oid, data.ID, sid)
+
+					if err != nil && (strings.Contains(err.Error(), "401") || lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
+						if errRecover := lc.recoverToken(ctx); errRecover == nil {
+							client = line.NewClient(lc.AccessToken)
+							audioData, err = client.DownloadOBSWithSID(oid, data.ID, sid)
+						}
+					}
+
+					if err != nil {
+						lc.UserLogin.Bridge.Log.Warn().
+							Err(err).
+							Str("oid", oid).
+							Str("msg_id", data.ID).
+							Bool("plain_media", isPlainMedia).
+							Msg("Failed to download audio from OBS, sending placeholder")
+						return &bridgev2.ConvertedMessage{
+							Parts: []*bridgev2.ConvertedMessagePart{
+								{
+									Type: event.EventMessage,
+									Content: &event.MessageEventContent{
+										MsgType:   event.MsgNotice,
+										Body:      "[Audio unavailable — LINE media expired before it could be bridged]",
+										RelatesTo: replyRelatesTo,
+									},
+								},
+							},
+						}, nil
+					}
+
+					// Decrypt audio if it has keyMaterial (E2EE)
+					if decryptedBody != "" && strings.Contains(decryptedBody, "keyMaterial") {
+						var decryptInfo struct {
+							KeyMaterial string `json:"keyMaterial"`
+						}
+						if err := json.Unmarshal([]byte(decryptedBody), &decryptInfo); err == nil && decryptInfo.KeyMaterial != "" {
+							decryptedAudio, err := lc.decryptImageData(audioData, decryptInfo.KeyMaterial)
+							if err != nil {
+								return nil, fmt.Errorf("failed to decrypt audio data: %w", err)
+							}
+							audioData = decryptedAudio
+						}
+					}
+
+					if encKM := data.ContentMetadata["ENC_KM"]; encKM != "" && len(audioData) > 32 {
+						decryptedAudio, err := lc.decryptImageData(audioData, encKM)
+						if err != nil {
+							return nil, fmt.Errorf("failed to decrypt audio data: %w", err)
+						}
+						audioData = decryptedAudio
+					}
+
+					var duration int
+					if durationStr := data.ContentMetadata["DURATION"]; durationStr != "" {
+						if d, err := strconv.Atoi(durationStr); err == nil {
+							duration = d
+						}
+					}
+
+					mxc, file, err := intent.UploadMedia(ctx, portal.MXID, audioData, "audio.m4a", "audio/mp4")
+					if err != nil {
+						return nil, fmt.Errorf("failed to upload audio to matrix: %w", err)
+					}
+
+					audioInfo := &event.FileInfo{
+						MimeType: "audio/mp4",
+						Size:     len(audioData),
+					}
+					if duration > 0 {
+						audioInfo.Duration = duration
+					}
+
+					return &bridgev2.ConvertedMessage{
+						Parts: []*bridgev2.ConvertedMessagePart{
+							{
+								Type: event.EventMessage,
+								Content: &event.MessageEventContent{
+									MsgType:   event.MsgAudio,
+									Body:      "audio.m4a",
+									URL:       mxc,
+									File:      file,
+									Info:      audioInfo,
 									RelatesTo: replyRelatesTo,
 								},
 							},

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -395,6 +395,51 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 				Msg("Prepared video message")
 		}
 
+	case event.MsgAudio:
+		data, err := lc.UserLogin.Bridge.Bot.DownloadMedia(ctx, msg.Content.URL, msg.Content.File)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download audio from matrix: %w", err)
+		}
+
+		contentType = int(ContentAudio)
+		contentMetadata["FILE_SIZE"] = fmt.Sprintf("%d", len(data))
+		contentMetadata["contentType"] = fmt.Sprintf("%d", ContentAudio)
+
+		if msg.Content.Info != nil && msg.Content.Info.Duration > 0 {
+			contentMetadata["DURATION"] = fmt.Sprintf("%d", msg.Content.Info.Duration)
+			contentMetadata["AUDLEN"] = fmt.Sprintf("%d", msg.Content.Info.Duration)
+		}
+
+		if plainText {
+			plainMediaData = data
+		} else {
+			if isGroup {
+				originalMediaData = data
+			}
+
+			uploadData, keyMaterialB64, err := lc.encryptFileData(data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt audio data: %w", err)
+			}
+
+			oid, err := client.UploadOBSWithSID(uploadData, "ema")
+			if err != nil {
+				return nil, fmt.Errorf("failed to upload audio to OBS: %w", err)
+			}
+
+			contentMetadata["OID"] = oid
+			contentMetadata["SID"] = "ema"
+			contentMetadata["ENC_KM"] = keyMaterialB64
+
+			audioPayload := map[string]string{"keyMaterial": keyMaterialB64}
+			payload, _ = json.Marshal(audioPayload)
+
+			lc.UserLogin.Bridge.Log.Info().
+				Str("oid", oid).
+				Int("upload_size", len(uploadData)).
+				Msg("Prepared audio message")
+		}
+
 	default:
 		return nil, fmt.Errorf("message type %s not implemented", msg.Content.MsgType)
 	}
@@ -518,6 +563,8 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		switch contentType {
 		case int(ContentVideo):
 			obsType = "video"
+		case int(ContentAudio):
+			obsType = "audio"
 		case int(ContentFile):
 			obsType = "file"
 		}

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -79,6 +79,14 @@ func (lc *LineClient) GetCapabilities(ctx context.Context, portal *bridgev2.Port
 					"audio/mp4":  event.CapLevelFullySupported,
 				},
 			},
+			event.CapMsgVoice: {
+				Caption: event.CapLevelRejected,
+				MimeTypes: map[string]event.CapabilitySupportLevel{
+					"audio/ogg":  event.CapLevelFullySupported,
+					"audio/mp4":  event.CapLevelFullySupported,
+					"audio/mpeg": event.CapLevelFullySupported,
+				},
+			},
 		},
 	}
 }

--- a/readme/LETTER_SEALING.md
+++ b/readme/LETTER_SEALING.md
@@ -121,8 +121,8 @@ The bridge determines E2EE capability per-chat before sending:
 | Video to `LSOFF` / plain chats | Plain (`m` upload) | Verified |
 | File to `LSON` peer | E2EE (`emf` upload) | Verified |
 | File to `LSOFF` / plain chats | Plain (`m` upload) | Verified |
-| Audio to `LSON` peer | E2EE (`ema` upload) | Not tested |
-| Audio to `LSOFF` / plain chats | Plain (`m` upload) | Not tested |
+| Audio to `LSON` peer | E2EE (`ema` upload) | Verified |
+| Audio to `LSOFF` / plain chats | Plain (`m` upload) | Verified |
 
 ### Media receive (incoming to Beeper)
 

--- a/readme/LETTER_SEALING.md
+++ b/readme/LETTER_SEALING.md
@@ -6,7 +6,7 @@ This note summarizes what issue [#42](https://github.com/highesttt/matrix-line-m
 
 - The bridge supports both `LSON` and `LSOFF` accounts for login and messaging.
 - Text messages work in all combinations: `LSON`/`LSOFF` direct messages, mixed groups, and business/bot accounts.
-- Image, video, and file sending works for all user types. E2EE media uses encrypted OBS upload; plain media uses the `r/talk/m` post-send upload path.
+- Image, video, file, and audio sending works for all user types. E2EE media uses encrypted OBS upload; plain media uses the `r/talk/m` post-send upload path.
 - Transparent PNGs are composited onto a white background before upload, matching LINE native client behavior.
 
 ## Terms
@@ -121,7 +121,8 @@ The bridge determines E2EE capability per-chat before sending:
 | Video to `LSOFF` / plain chats | Plain (`m` upload) | Verified |
 | File to `LSON` peer | E2EE (`emf` upload) | Verified |
 | File to `LSOFF` / plain chats | Plain (`m` upload) | Verified |
-| Audio send (any) | Not implemented | Known gap |
+| Audio to `LSON` peer | E2EE (`ema` upload) | Not tested |
+| Audio to `LSOFF` / plain chats | Plain (`m` upload) | Not tested |
 
 ### Media receive (incoming to Beeper)
 
@@ -133,6 +134,8 @@ The bridge determines E2EE capability per-chat before sending:
 | Incoming video from E2EE chat | E2EE (`emv` download) | Not tested |
 | Incoming file from plain chat | Plain (`m` download) | Not tested |
 | Incoming file from E2EE chat | E2EE (`emf` download) | Not tested |
+| Incoming audio from plain chat | Plain (`m` download) | Verified |
+| Incoming audio from E2EE chat | E2EE (`ema` download) | Verified |
 
 ### Re-login and token refresh
 


### PR DESCRIPTION
## Summary

- Add `ContentAudio` (type 3) to supported content types
- Handle incoming audio from both E2EE (OBS SID `ema` + keyMaterial decryption) and plain (`r/talk/m/{messageID}`) paths
- Handle outgoing audio: E2EE encrypts and uploads to `ema`, plain uploads to `r/talk/m` after send
- Declare `CapMsgVoice` (`org.matrix.msc3245.voice`) capability so Beeper enables the record button
- Restore `syncDMChats` in `Connect()` (accidentally removed in token refresh commit) so DM portals get capability updates on startup
- Graceful placeholder on download failure
- Update README and Letter Sealing docs

Closes #76

## Problem (before)

### Receive (LINE → Beeper)

```mermaid
flowchart TD
    A[LINE user sends voice message] --> B{Content type 3?}
    B --> C[Unknown — silently dropped]
    C --> D[Beeper user never hears it]
    
    style C fill:#e76f51,color:#fff
    style D fill:#e76f51,color:#fff
```

### Send (Beeper → LINE)

```mermaid
flowchart TD
    E[Beeper user wants to record voice] --> F[Record button greyed out]
    F --> G[CapMsgVoice not declared]
    G --> H[Cannot send audio]
    
    style F fill:#e76f51,color:#fff
    style H fill:#e76f51,color:#fff
```

## Solution (after)

### Receive (LINE → Beeper)

```mermaid
flowchart TD
    A[LINE user sends voice message] --> B{E2EE or plain?}
    B -->|E2EE: OID + SID=ema| C[Download from OBS]
    C --> D[Decrypt with keyMaterial]
    D --> E[Upload to Matrix as MsgAudio]
    B -->|Plain: no OID| F[Download from r/talk/m/messageID]
    F --> E
    E --> G[Audio plays on Beeper with duration]
    
    style G fill:#2d6a4f,color:#fff
```

### Send (Beeper → LINE)

```mermaid
flowchart TD
    H[Beeper user records voice] --> I{E2EE or plain?}
    I -->|E2EE| J[Encrypt with encryptFileData]
    J --> K[Upload to OBS SID ema]
    K --> L[Send message with OID + keyMaterial]
    I -->|Plain| M[Send message first]
    M --> N[Upload raw audio to r/talk/m/msgId]
    L --> O[Audio plays on LINE]
    N --> O
    
    style O fill:#2d6a4f,color:#fff
```

## Test plan

- [x] Receive audio from LSON (E2EE) user — plays on Beeper
- [x] Receive audio from LSOFF (plain) user — plays on Beeper
- [x] Send voice from Beeper to LSON user — plays on LINE
- [x] Send voice from Beeper to LSOFF user — plays on LINE
- [x] Record button enabled on Beeper Desktop and Mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)