### PR TITLE
fix: remove double-close on temp video file in extractVideoThumbnail

### DIFF
--- a/pkg/connector/media.go
+++ b/pkg/connector/media.go
@@ -260,7 +260,6 @@ func extractVideoThumbnail(videoData []byte) ([]byte, int, int, error) {
 		return nil, 0, 0, fmt.Errorf("failed to create temp video file: %w", err)
 	}
 	defer os.Remove(tmpVideoFile.Name())
-	defer tmpVideoFile.Close()
 
 	if _, err := tmpVideoFile.Write(videoData); err != nil {
 		return nil, 0, 0, fmt.Errorf("failed to write video data: %w", err)


### PR DESCRIPTION
## Summary

Fixes #82

`extractVideoThumbnail` in `pkg/connector/media.go` had both a `defer tmpVideoFile.Close()` and an explicit `tmpVideoFile.Close()` two lines later. The explicit close is needed before ffmpeg reads the file; the deferred close is a redundant double-close.

### Before / After

```
BEFORE                                  AFTER
──────                                  ─────
tmpVideoFile = os.CreateTemp(...)       tmpVideoFile = os.CreateTemp(...)
defer os.Remove(tmpVideoFile.Name())    defer os.Remove(tmpVideoFile.Name())
defer tmpVideoFile.Close()  ← redundant
                                        
tmpVideoFile.Write(videoData)           tmpVideoFile.Write(videoData)
tmpVideoFile.Close()  ← explicit        tmpVideoFile.Close()  ← only close
                                        
ffmpeg reads the file...                ffmpeg reads the file...
                                        
function returns:                       function returns:
  defers run in LIFO order:               defers run:
  1. tmpVideoFile.Close() ← double!        1. os.Remove() ✅
  2. os.Remove() ✅
```

One-line removal in `pkg/connector/media.go`.

## Test plan

- [ ] Video messages still generate thumbnails correctly
- [ ] No file descriptor warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)