### PR TITLE
fix: prevent IsNoUsableE2EEGroupKey from matching token logout errors

### DIFF
--- a/pkg/line/errors.go
+++ b/pkg/line/errors.go
@@ -45,7 +45,9 @@ func IsNoUsableE2EEGroupKey(err error) bool {
 	// Code 5 "not found" = no group shared key; Code 98 = member has LS off;
 	// Code 1 "Authentication Failed" from getE2EEGroupSharedKey also indicates no key access.
 	if strings.Contains(msg, "\"code\":10051") && strings.Contains(msg, "talkexception") {
-		if strings.Contains(msg, "\"code\":5") || strings.Contains(msg, "\"code\":98") || strings.Contains(msg, "\"code\":1") {
+		if strings.Contains(msg, "\"code\":5,") || strings.Contains(msg, "\"code\":5}") ||
+			strings.Contains(msg, "\"code\":98,") || strings.Contains(msg, "\"code\":98}") ||
+			strings.Contains(msg, "\"code\":1,") || strings.Contains(msg, "\"code\":1}") {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #88

### Before / After

```
BEFORE                                    AFTER
──────                                    ─────
Error: "code":10051 ... "code":8          Error: "code":10051 ... "code":8
       V3_TOKEN_CLIENT_LOGGED_OUT                V3_TOKEN_CLIENT_LOGGED_OUT

IsNoUsableE2EEGroupKey checks:            IsNoUsableE2EEGroupKey checks:
  "code":10051 ✓ (outer code)               "code":10051 ✓ (outer code)
  "talkexception" ✓                         "talkexception" ✓
  "code":1 ← matches "code":10051!         "code":1, or "code":1} ← no match
  → returns TRUE (wrong!)                   → returns FALSE (correct!)

isTokenError → false (excluded)           isTokenError → true
callWithRecovery → no recovery            callWithRecovery → recoverToken()
BAD_CREDENTIALS → never sent              BAD_CREDENTIALS → sent ✅
Beeper → no reconnect prompt              Beeper → shows reconnect banner
```

One-line fix in `pkg/line/errors.go`: match `"code":1,` / `"code":1}` instead of `"code":1` to prevent substring false positive with `"code":10051`.

## Test plan

- [x] Verified: login from Chrome Extension, send message → recovery triggers, BAD_CREDENTIALS sent
- [x] Verified: Beeper shows disconnected banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)