### PR TITLE
feat: display LINE call notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Based on the [mautrix-twilio](https://github.com/mautrix/twilio) bridge
 - [x] Sticker retrieval support
 - [x] Link previews
 - [x] Message unsending/deletion
+- [x] Call notifications (voice and video, with duration)
 - [x] Leaving chats
 
 ## Setup

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -156,6 +156,48 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 		ID:   networkid.MessageID(msg.ID),
 		ConvertMessageFunc: func(ctx context.Context, portal *bridgev2.Portal, intent bridgev2.MatrixAPI, data line.Message) (*bridgev2.ConvertedMessage, error) {
 			replyRelatesTo := lc.resolveReplyRelatesTo(ctx, &data)
+
+			// Handle call events (ORGCONTP == "CALL")
+			if data.ContentMetadata["ORGCONTP"] == "CALL" {
+				callType := "Voice"
+				if data.ContentMetadata["TYPE"] == "V" {
+					callType = "Video"
+				}
+
+				durationMs, _ := strconv.Atoi(data.ContentMetadata["DURATION"])
+				duration := durationMs / 1000
+				result := data.ContentMetadata["RESULT"]
+
+				var body string
+				switch {
+				case duration > 0:
+					mins := duration / 60
+					secs := duration % 60
+					if mins > 0 {
+						body = fmt.Sprintf("%s call (%dm%02ds)", callType, mins, secs)
+					} else {
+						body = fmt.Sprintf("%s call (%ds)", callType, secs)
+					}
+				case result == "CANCELED":
+					body = fmt.Sprintf("Missed %s call", strings.ToLower(callType))
+				default:
+					body = fmt.Sprintf("Missed %s call", strings.ToLower(callType))
+				}
+
+				return &bridgev2.ConvertedMessage{
+					Parts: []*bridgev2.ConvertedMessagePart{
+						{
+							Type: event.EventMessage,
+							Content: &event.MessageEventContent{
+								MsgType:   event.MsgNotice,
+								Body:      body,
+								RelatesTo: replyRelatesTo,
+							},
+						},
+					},
+				}, nil
+			}
+
 			// Handle Images
 			client := line.NewClient(lc.AccessToken)
 			if ContentType(data.ContentType) == ContentImage {


### PR DESCRIPTION
## Summary

Closes #92

- Detect call events via `contentMetadata["ORGCONTP"] == "CALL"` (protocol-level, not text matching)
- Distinguish voice (`TYPE=A`) vs video (`TYPE=V`) calls
- Differentiate outcomes: missed calls vs answered calls with duration
- Render as `m.notice` for clean notification-style display

### Call display examples

| Scenario | Display |
|----------|---------|
| Missed voice call | `Missed voice call` |
| Missed video call | `Missed video call` |
| Answered voice call (1m23s) | `Voice call (1m23s)` |
| Answered video call (45s) | `Video call (45s)` |

## Before / After

```mermaid
flowchart TD
    subgraph Before
        A[LINE call event arrives] --> B{contentType?}
        B -->|contentType: 0| C[Treated as text message]
        C --> D["Displays: 'Your OS version doesn't support this feature.'"]
        D --> E[❌ Confusing, no call info]
    end
```

```mermaid
flowchart TD
    subgraph After
        A2[LINE call event arrives] --> B2{contentType: 0}
        B2 --> C2{ORGCONTP == CALL?}
        C2 -->|No| D2[Process as normal text]
        C2 -->|Yes| E2{Check DURATION}
        E2 -->|duration > 0| F2["Voice call (1m23s)"]
        E2 -->|duration == 0| G2{Check RESULT}
        G2 -->|CANCELED| H2["Missed voice call"]
        G2 -->|other| I2["Missed voice call"]
        F2 --> J2[✅ m.notice to Matrix]
        H2 --> J2
        I2 --> J2
    end
```

```mermaid
sequenceDiagram
    participant Phone as LINE Phone App
    participant Server as LINE Server
    participant Bridge as LINE Bridge (Chrome Ext)
    participant Matrix as Matrix/Beeper

    Phone->>Server: Initiate/receive call
    Note over Phone,Server: Call happens on phone
    Server->>Bridge: SSE operation (type 25/26)
    Note right of Bridge: contentType: 0<br/>ORGCONTP: "CALL"<br/>TYPE: "A"/"V"<br/>RESULT: "CANCELED"<br/>DURATION: "0"/"123"
    Bridge->>Bridge: Check ORGCONTP == "CALL"
    Bridge->>Bridge: Format based on TYPE, RESULT, DURATION
    Bridge->>Matrix: m.notice "Missed voice call"
```

## Test plan

- [ ] Missed voice call shows "Missed voice call"
- [ ] Missed video call shows "Missed video call"
- [ ] Answered call with duration shows "Voice call (Xm XXs)"
- [ ] Verify no false positives on regular text messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)