### PR TITLE
feat: support message unsending with 24h limit

### DIFF
--- a/UNSENDING.md
+++ b/UNSENDING.md
@@ -1,0 +1,25 @@
+# Message Unsending / Deletion
+
+## How it works
+
+The bridge supports unsending (deleting) messages in both directions:
+
+- **Matrix -> LINE**: When you delete a message in your Matrix client (e.g. "Delete for Everyone" in Beeper), the bridge calls LINE's `unsendMessage` API.
+- **LINE -> Matrix**: When someone unsends a message on LINE, the bridge receives the operation and redacts the message on the Matrix side.
+
+## 24-hour limit (free accounts)
+
+LINE imposes a **24-hour limit** on unsending messages for free accounts. If you try to unsend a message older than 24 hours, LINE rejects the request with:
+
+```
+TalkException code 71: "message too old"
+messageUnsendPeriodMillis: 86400000 (24h)
+```
+
+The bridge advertises this limit via `DeleteMaxAge: 24h` in the room capabilities, so Matrix clients that support this field (like Beeper) should hide the "Delete for Everyone" option for messages older than 24 hours.
+
+As a fallback, if a client ignores `DeleteMaxAge` and attempts the unsend anyway, the bridge returns a permanent failure with a notice: _"message too old to unsend on LINE (24h limit)"_.
+
+## Paid accounts
+
+LINE paid accounts may have the ability to unsend messages at any time. This is not yet specifically handled by the bridge -- the 24-hour limit is applied uniformly. If you have a paid account and need this, please open an issue.

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -84,8 +84,7 @@ func (lc *LineClient) isRefreshRequired(err error) bool {
 
 func (lc *LineClient) isLoggedOut(err error) bool {
 	msg := err.Error()
-	return strings.Contains(msg, "V3_TOKEN_CLIENT_LOGGED_OUT") ||
-		strings.Contains(msg, "\"code\":10051")
+	return strings.Contains(msg, "V3_TOKEN_CLIENT_LOGGED_OUT")
 }
 
 // recoverToken attempts to restore a valid session by refreshing, then re-logging in.

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -606,7 +606,15 @@ func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridge
 	lc.sentReqSeqs[reqSeq] = time.Now()
 	lc.reqSeqMu.Unlock()
 
-	return client.UnsendMessage(int64(reqSeq), string(msg.TargetMessage.ID))
+	err := client.UnsendMessage(int64(reqSeq), string(msg.TargetMessage.ID))
+	if err != nil && strings.Contains(err.Error(), "message too old") {
+		return bridgev2.WrapErrorInStatus(fmt.Errorf("message too old to unsend on LINE (24h limit)")).
+			WithStatus(event.MessageStatusFail).
+			WithErrorReason(event.MessageStatusTooOld).
+			WithIsCertain(true).
+			WithSendNotice(true)
+	}
+	return err
 }
 
 func (lc *LineClient) HandleMatrixLeaveRoom(ctx context.Context, portal *bridgev2.Portal) error {

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"go.mau.fi/util/jsontime"
 	"go.mau.fi/util/ptr"
 
 	"maunium.net/go/mautrix/bridgev2"
@@ -45,7 +46,8 @@ func (lc *LineClient) GetCapabilities(ctx context.Context, portal *bridgev2.Port
 		MaxTextLength:         5000,
 		Reply:                 event.CapLevelFullySupported,
 		ReadReceipts:          true,
-		Delete:                event.CapLevelPartialSupport,
+		Delete:                event.CapLevelFullySupported,
+		DeleteMaxAge:          &jsontime.Seconds{Duration: 24 * time.Hour},
 		DeleteChatForEveryone: true,
 		File: event.FileFeatureMap{
 			event.MsgImage: {


### PR DESCRIPTION
## Summary
- Advertise `Delete: CapLevelFullySupported` with `DeleteMaxAge: 24h` so Beeper hides "Delete for Everyone" for messages older than 24 hours
- Return `FAIL_PERMANENT` with `m.event_too_old` and a notice when LINE rejects an unsend for old messages, instead of silently failing or triggering token recovery
- Remove blanket `"code":10051` check from `isLoggedOut()` — this was incorrectly treating all TalkExceptions as logout events, causing session disconnects on failed unsends

Closes #91

## Before

### Unsend recent message (< 24h)
```mermaid
sequenceDiagram
    participant User as Beeper Desktop
    participant Bridge
    participant LINE

    User->>Bridge: Redact message
    Note over User: "Delete for Everyone" hidden<br/>(CapLevelPartialSupport)
    Bridge--xUser: Option not available on desktop
```

### Unsend old message (> 24h)
```mermaid
sequenceDiagram
    participant User as Beeper Desktop
    participant Bridge
    participant LINE

    User->>Bridge: Redact message (mobile)
    Bridge->>LINE: UnsendMessage()
    LINE-->>Bridge: Error 10051 code 71<br/>"message too old"
    Bridge->>Bridge: isLoggedOut() matches "code":10051
    Bridge->>Bridge: Triggers token recovery
    Bridge->>LINE: Re-login attempt
    LINE-->>Bridge: PIN required (cert expired)
    Bridge-->>User: BAD_CREDENTIALS<br/>Session disconnected
    Note over User: Message disappears from Beeper<br/>but still exists on LINE
```

## After

### Unsend recent message (< 24h)
```mermaid
sequenceDiagram
    participant User as Beeper Desktop
    participant Bridge
    participant LINE

    User->>Bridge: Redact message
    Note over User: "Delete for Everyone" visible<br/>(CapLevelFullySupported)
    Bridge->>LINE: UnsendMessage()
    LINE-->>Bridge: Success
    Bridge->>LINE: Receives OpUnsendLocal (64)
    Bridge-->>User: Message redacted on both sides
```

### Unsend old message (> 24h)
```mermaid
sequenceDiagram
    participant User as Beeper Desktop
    participant Bridge
    participant LINE

    Note over User: DeleteMaxAge: 24h<br/>Option hidden for old messages
    User->>Bridge: Redact message (if attempted)
    Bridge->>LINE: UnsendMessage()
    LINE-->>Bridge: Error 10051 code 71<br/>"message too old"
    Bridge->>Bridge: isLoggedOut() does NOT match
    Bridge-->>User: FAIL_PERMANENT + notice<br/>"message too old to unsend on LINE (24h limit)"
    Note over User: Message preserved in Beeper<br/>Session stays connected
```

## Test plan
- [x] Delete a recent message (< 24h) from Beeper Desktop — unsends on LINE, disappears on both sides
- [x] Delete an old message (> 24h) — LINE rejects, bridge returns FAIL_PERMANENT with notice, session stays connected
- [x] "Delete for Everyone" button now appears on Beeper Desktop (was missing due to CapLevelPartialSupport)
- [x] Verify DeleteMaxAge hides the option for messages older than 24h on Beeper Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)