### PR TITLE
fix: proactive token refresh, recovery serialization, and callWithRecovery

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -32,6 +32,12 @@ type LineClient struct {
 	noE2EEGroups   map[string]time.Time // chatMid -> when group E2EE failure was cached
 	contactCache   map[string]cachedContact
 	mediaFlowCache map[string]cachedMediaFlow
+
+	refreshTimer            *time.Timer
+	durationUntilRefreshSec int64
+
+	recoverMu   sync.Mutex
+	recoverTime time.Time
 }
 
 type cachedMediaFlow struct {
@@ -119,10 +125,22 @@ func (lc *LineClient) refreshAndSave(ctx context.Context) error {
 	if res.RefreshToken != "" {
 		lc.RefreshToken = res.RefreshToken
 	}
+	if res.DurationUntilRefreshSec != "" {
+		if d, err := strconv.ParseInt(res.DurationUntilRefreshSec, 10, 64); err == nil {
+			lc.durationUntilRefreshSec = d
+		}
+	}
+
+	// Validate the new token with a lightweight API call before persisting it
+	validationClient := line.NewClient(lc.AccessToken)
+	if _, err := validationClient.GetProfile(); err != nil {
+		return fmt.Errorf("refreshed token failed validation: %w", err)
+	}
 
 	meta := lc.UserLogin.Metadata.(*UserLoginMetadata)
 	meta.AccessToken = lc.AccessToken
 	meta.RefreshToken = lc.RefreshToken
+	meta.DurationUntilRefreshSec = lc.durationUntilRefreshSec
 	err = lc.UserLogin.Save(ctx)
 	if err != nil {
 		lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to save refreshed tokens to DB")
@@ -131,6 +149,42 @@ func (lc *LineClient) refreshAndSave(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// isTokenError returns true if the error indicates the access token is expired,
+// invalid, or the session was logged out from another device.
+// It returns false for E2EE key-specific errors that resemble auth errors.
+func (lc *LineClient) isTokenError(err error) bool {
+	if err == nil {
+		return false
+	}
+	isE2EEGroup := line.IsNoUsableE2EEGroupKey(err)
+	isE2EEPub := line.IsNoUsableE2EEPublicKey(err)
+	if isE2EEGroup || isE2EEPub {
+		return false
+	}
+	isRefresh := lc.isRefreshRequired(err)
+	isLogged := lc.isLoggedOut(err)
+	has401 := strings.Contains(err.Error(), "401")
+	has403 := strings.Contains(err.Error(), "403")
+	return isRefresh || isLogged || has401 || has403
+}
+
+// callWithRecovery creates a LINE API client and calls fn. If the call fails
+// with a token error, it recovers the session and retries once.
+// Returns the (possibly refreshed) client so callers can reuse it.
+func (lc *LineClient) callWithRecovery(ctx context.Context, fn func(*line.Client) error) (*line.Client, error) {
+	client := line.NewClient(lc.AccessToken)
+	err := fn(client)
+	if err != nil && lc.isTokenError(err) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			err = fn(client)
+		} else {
+			lc.UserLogin.Bridge.Log.Warn().Err(errRecover).Msg("callWithRecovery: recovery failed")
+		}
+	}
+	return client, err
 }
 
 func (lc *LineClient) isRefreshRequired(err error) bool {
@@ -143,14 +197,35 @@ func (lc *LineClient) isLoggedOut(err error) bool {
 }
 
 // recoverToken attempts to restore a valid session by refreshing, then re-logging in.
-// Returns nil on success. On failure the caller should send StateBadCredentials.
+// Returns nil on success. On failure it sends StateBadCredentials automatically.
+// Concurrent callers are serialized; if recovery happened within the last 10 seconds
+// the call is a no-op (the token was already refreshed by another goroutine).
 func (lc *LineClient) recoverToken(ctx context.Context) error {
+	lc.recoverMu.Lock()
+	defer lc.recoverMu.Unlock()
+
+	if time.Since(lc.recoverTime) < 10*time.Second {
+		lc.UserLogin.Bridge.Log.Debug().Msg("Skipping token recovery — already recovered recently")
+		return nil
+	}
+
 	if err := lc.refreshAndSave(ctx); err == nil {
 		lc.UserLogin.Bridge.Log.Info().Msg("Token recovered via refresh")
+		lc.scheduleTokenRefresh()
+		lc.recoverTime = time.Now()
 		return nil
 	}
 	lc.UserLogin.Bridge.Log.Info().Msg("Refresh failed, attempting re-login with stored credentials...")
-	return lc.tryLogin(ctx)
+	if err := lc.tryLogin(ctx); err != nil {
+		lc.UserLogin.BridgeState.Send(status.BridgeState{
+			StateEvent: status.StateBadCredentials,
+			Message:    fmt.Sprintf("Token recovery failed: %v", err),
+		})
+		return err
+	}
+	lc.scheduleTokenRefresh()
+	lc.recoverTime = time.Now()
+	return nil
 }
 
 func (lc *LineClient) Connect(ctx context.Context) {
@@ -191,6 +266,8 @@ func (lc *LineClient) Connect(ctx context.Context) {
 		})
 		return
 	}
+
+	lc.scheduleTokenRefresh()
 
 	lc.UserLogin.Bridge.Log.Info().Int("token_len", len(lc.AccessToken)).Msg("LINE client connected; notifying bridge")
 	lc.UserLogin.BridgeState.Send(status.BridgeState{
@@ -293,6 +370,11 @@ func (lc *LineClient) tryLogin(ctx context.Context) error {
 		if res.TokenV3IssueResult.RefreshToken != "" {
 			lc.RefreshToken = res.TokenV3IssueResult.RefreshToken
 		}
+		if res.TokenV3IssueResult.DurationUntilRefreshSec != "" {
+			if d, err := strconv.ParseInt(res.TokenV3IssueResult.DurationUntilRefreshSec, 10, 64); err == nil {
+				lc.durationUntilRefreshSec = d
+			}
+		}
 	}
 	if res.Mid != "" {
 		lc.Mid = res.Mid
@@ -346,7 +428,37 @@ func (lc *LineClient) ensureValidToken(ctx context.Context) error {
 	return lc.tryLogin(ctx)
 }
 
-func (lc *LineClient) Disconnect() {}
+// scheduleTokenRefresh sets a timer to proactively refresh the access token
+// before it expires. The timer fires 5 minutes before the server-reported
+// expiration so the bridge never operates with a stale token.
+func (lc *LineClient) scheduleTokenRefresh() {
+	if lc.durationUntilRefreshSec <= 0 {
+		return
+	}
+	const marginSec = 5 * 60
+	delaySec := lc.durationUntilRefreshSec - marginSec
+	if delaySec < 60 {
+		delaySec = 60
+	}
+	if lc.refreshTimer != nil {
+		lc.refreshTimer.Stop()
+	}
+	lc.refreshTimer = time.AfterFunc(time.Duration(delaySec)*time.Second, func() {
+		lc.UserLogin.Bridge.Log.Info().Int64("delay_sec", delaySec).Msg("Proactive token refresh triggered")
+		if err := lc.refreshAndSave(context.Background()); err != nil {
+			lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Proactive token refresh failed")
+			return
+		}
+		lc.scheduleTokenRefresh()
+	})
+	lc.UserLogin.Bridge.Log.Info().Int64("delay_sec", delaySec).Msg("Scheduled proactive token refresh")
+}
+
+func (lc *LineClient) Disconnect() {
+	if lc.refreshTimer != nil {
+		lc.refreshTimer.Stop()
+	}
+}
 
 func (lc *LineClient) IsLoggedIn() bool { return lc.AccessToken != "" }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -77,16 +77,16 @@ func (lc *LineConnector) GetDBMetaTypes() database.MetaTypes {
 }
 
 type UserLoginMetadata struct {
-	AccessToken       string            `json:"access_token"`
-	RefreshToken      string            `json:"refresh_token,omitempty"`
-	Email             string            `json:"email,omitempty"`
-	Password          string            `json:"password,omitempty"`
-	Certificate       string            `json:"certificate,omitempty"`
-	Mid               string            `json:"mid,omitempty"`
-	EncryptedKeyChain string            `json:"encrypted_key_chain,omitempty"`
-	E2EEPublicKey     string            `json:"e2ee_public_key,omitempty"`
-	E2EEVersion       string            `json:"e2ee_version,omitempty"`
-	E2EEKeyID         string            `json:"e2ee_key_id,omitempty"`
+	AccessToken             string            `json:"access_token"`
+	RefreshToken            string            `json:"refresh_token,omitempty"`
+	Email                   string            `json:"email,omitempty"`
+	Password                string            `json:"password,omitempty"`
+	Certificate             string            `json:"certificate,omitempty"`
+	Mid                     string            `json:"mid,omitempty"`
+	EncryptedKeyChain       string            `json:"encrypted_key_chain,omitempty"`
+	E2EEPublicKey           string            `json:"e2ee_public_key,omitempty"`
+	E2EEVersion             string            `json:"e2ee_version,omitempty"`
+	E2EEKeyID               string            `json:"e2ee_key_id,omitempty"`
 	ExportedKeyMap          map[string]string `json:"exported_key_map,omitempty"`
 	DurationUntilRefreshSec int64             `json:"duration_until_refresh_sec,omitempty"`
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -86,17 +87,19 @@ type UserLoginMetadata struct {
 	E2EEPublicKey     string            `json:"e2ee_public_key,omitempty"`
 	E2EEVersion       string            `json:"e2ee_version,omitempty"`
 	E2EEKeyID         string            `json:"e2ee_key_id,omitempty"`
-	ExportedKeyMap    map[string]string `json:"exported_key_map,omitempty"`
+	ExportedKeyMap          map[string]string `json:"exported_key_map,omitempty"`
+	DurationUntilRefreshSec int64             `json:"duration_until_refresh_sec,omitempty"`
 }
 
 func (lc *LineConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLogin) error {
 	meta := login.Metadata.(*UserLoginMetadata)
 	login.Client = &LineClient{
-		UserLogin:    login,
-		AccessToken:  meta.AccessToken,
-		RefreshToken: meta.RefreshToken,
-		Mid:          meta.Mid,
-		HTTPClient:   &http.Client{Timeout: 10 * time.Second},
+		UserLogin:               login,
+		AccessToken:             meta.AccessToken,
+		RefreshToken:            meta.RefreshToken,
+		Mid:                     meta.Mid,
+		HTTPClient:              &http.Client{Timeout: 10 * time.Second},
+		durationUntilRefreshSec: meta.DurationUntilRefreshSec,
 	}
 	return nil
 }
@@ -338,6 +341,11 @@ func (ll *LineEmailLogin) finishLogin(ctx context.Context, res *line.LoginResult
 	}
 
 	meta := &UserLoginMetadata{AccessToken: token, RefreshToken: refreshToken, Email: ll.Email, Password: ll.Password, Certificate: res.Certificate, Mid: res.Mid}
+	if res.TokenV3IssueResult != nil && res.TokenV3IssueResult.DurationUntilRefreshSec != "" {
+		if d, err := strconv.ParseInt(res.TokenV3IssueResult.DurationUntilRefreshSec, 10, 64); err == nil {
+			meta.DurationUntilRefreshSec = d
+		}
+	}
 	if res.EncryptedKeyChain != "" && res.E2EEPublicKey != "" {
 		meta.EncryptedKeyChain = res.EncryptedKeyChain
 		meta.E2EEPublicKey = res.E2EEPublicKey

--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -73,7 +73,7 @@ func (lc *LineClient) fetchAndUnwrapGroupKey(ctx context.Context, chatMid string
 	return nil
 }
 
-func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string, error) {
+func (lc *LineClient) ensurePeerKey(ctx context.Context, mid string) (int, string, error) {
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
@@ -93,6 +93,12 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 	}
 	client := line.NewClient(lc.AccessToken)
 	res, err := client.NegotiateE2EEPublicKey(mid)
+	if err != nil && !line.IsNoUsableE2EEPublicKey(err) && lc.isTokenError(err) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			res, err = client.NegotiateE2EEPublicKey(mid)
+		}
+	}
 	if err != nil {
 		// Cache negative result so we don't keep hitting the API
 		if line.IsNoUsableE2EEPublicKey(err) {
@@ -135,7 +141,7 @@ func (lc *LineClient) clearGroupNoE2EE(chatMid string) {
 	delete(lc.noE2EEGroups, chatMid)
 }
 
-func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int) (int, string, error) {
+func (lc *LineClient) ensurePeerKeyByID(ctx context.Context, mid string, keyID int) (int, string, error) {
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
@@ -149,6 +155,12 @@ func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int
 	client := line.NewClient(lc.AccessToken)
 	// keyVersion 1
 	res, err := client.GetE2EEPublicKey(mid, 1, keyID)
+	if err != nil && lc.isTokenError(err) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			res, err = client.GetE2EEPublicKey(mid, 1, keyID)
+		}
+	}
 	if err != nil {
 		return 0, "", err
 	}

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -583,7 +583,12 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 	lc.sentReqSeqs[reqSeq] = time.Now()
 	lc.reqSeqMu.Unlock()
 
-	sentMsg, err := client.SendMessage(int64(reqSeq), lineMsg)
+	var sentMsg *line.Message
+	client, err = lc.callWithRecovery(ctx, func(c *line.Client) error {
+		var e error
+		sentMsg, e = c.SendMessage(int64(reqSeq), lineMsg)
+		return e
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -642,8 +647,6 @@ func contentTypeForMsgType(msgType event.MessageType) int {
 }
 
 func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridgev2.MatrixMessageRemove) error {
-	client := line.NewClient(lc.AccessToken)
-
 	reqSeq := int(time.Now().UnixMilli() % 1_000_000_000)
 	lc.reqSeqMu.Lock()
 	if lc.sentReqSeqs == nil {
@@ -652,7 +655,9 @@ func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridge
 	lc.sentReqSeqs[reqSeq] = time.Now()
 	lc.reqSeqMu.Unlock()
 
-	err := client.UnsendMessage(int64(reqSeq), string(msg.TargetMessage.ID))
+	_, err := lc.callWithRecovery(ctx, func(c *line.Client) error {
+		return c.UnsendMessage(int64(reqSeq), string(msg.TargetMessage.ID))
+	})
 	if err != nil && strings.Contains(err.Error(), "message too old") {
 		return bridgev2.WrapErrorInStatus(fmt.Errorf("message too old to unsend on LINE (24h limit)")).
 			WithStatus(event.MessageStatusFail).
@@ -664,8 +669,6 @@ func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridge
 }
 
 func (lc *LineClient) HandleMatrixLeaveRoom(ctx context.Context, portal *bridgev2.Portal) error {
-	client := line.NewClient(lc.AccessToken)
-
 	reqSeq := int(time.Now().UnixMilli() % 1_000_000_000)
 	lc.reqSeqMu.Lock()
 	if lc.sentReqSeqs == nil {
@@ -674,5 +677,8 @@ func (lc *LineClient) HandleMatrixLeaveRoom(ctx context.Context, portal *bridgev
 	lc.sentReqSeqs[reqSeq] = time.Now()
 	lc.reqSeqMu.Unlock()
 
-	return client.SendChatRemoved(int64(reqSeq), string(portal.ID), "0", 0)
+	_, err := lc.callWithRecovery(ctx, func(c *line.Client) error {
+		return c.SendChatRemoved(int64(reqSeq), string(portal.ID), "0", 0)
+	})
+	return err
 }


### PR DESCRIPTION
> [!NOTE]
> Pre-requisite for #113

## Summary
- Proactive token refresh 5 minutes before server-reported expiry
- Serialize concurrent recovery with mutex + 10s debounce to prevent stampede
- Validate refreshed tokens with `GetProfile` before persisting
- `callWithRecovery()` wrapper retries `SendMessage`, `UnsendMessage`, `SendChatRemoved` once after token recovery
- `isTokenError()` detects expired/invalid tokens while excluding E2EE key errors
- Token recovery added to `ensurePeerKey` and `ensurePeerKeyByID` so E2EE negotiation triggers recovery instead of failing silently
- Persist `DurationUntilRefreshSec` in metadata so refresh schedule survives restarts
- Auto-send `StateBadCredentials` on recovery failure

## Before (the bug)

```mermaid
graph TD
    A[Token expires] --> B[User sends message]
    B --> C[SendMessage / ensurePeerKey]
    C --> D{API error}
    D -->|SendMessage| E["'Unknown error occurred'<br/>shown to user"]
    D -->|ensurePeerKey| F["'failed to get peer key'<br/>silent failure"]
    E --> G[No recovery attempted]
    F --> G
    G --> H["Bridge stays 'connected'<br/>all messages fail silently"]

    style E fill:#f44,color:#fff
    style F fill:#f44,color:#fff
    style H fill:#f44,color:#fff
```

No proactive refresh, no retry on token errors in the send path or E2EE key path, no stampede protection when multiple goroutines detect expiry.

## After

### Token refresh lifecycle

```mermaid
graph LR
    A[Token issued] --> B[scheduleTokenRefresh]
    B --> C[Timer fires 5min before expiry]
    C --> D[refreshAndSave]
    D --> E[GetProfile validates]
    E --> F[Save to DB]
    F --> B
```

If timer misses (e.g. bridge restart):

```mermaid
graph LR
    A[API call fails] --> B[callWithRecovery]
    B --> C{isTokenError?}
    C -->|yes| D[recoverToken]
    D --> E[Retry API call]
    C -->|no| F[Return error]
```

### Recovery stampede prevention

```mermaid
sequenceDiagram
    participant A as goroutine A
    participant B as goroutine B
    participant C as goroutine C
    participant M as recoverMu

    A->>M: Lock
    M-->>A: acquired
    A->>A: recover + set recoverTime
    A->>M: Unlock
    B->>M: Lock
    M-->>B: acquired
    B->>B: <10s? skip
    B->>M: Unlock
    C->>M: Lock
    M-->>C: acquired
    C->>C: <10s? skip
    C->>M: Unlock
```

## Test plan

Tested:
- [x] Expired token triggers recovery via `ensureValidToken` → `recoverToken` (confirmed `V3_TOKEN_CLIENT_LOGGED_OUT` in logs)
- [x] Failed refresh falls back to re-login, sends `StateBadCredentials` if both fail (confirmed in bridge state logs)
- [x] `StateBadCredentials` includes `remote_profile.name` and `ttl:21600` (confirmed in bridge state payload)
- [x] Bridge reconnects successfully after re-login (confirmed `LINE client connected` in logs)

Code-review only (not practically testable without mocking):
- [ ] Proactive refresh timer fires before expiry — requires waiting for near-expiry
- [ ] Concurrent recovery stampede — requires multiple goroutines hitting token errors simultaneously
- [ ] `GetProfile` validation rejects broken refreshed tokens — requires refresh endpoint to return bad token
- [ ] `Disconnect()` stops refresh timer — trivial (`timer.Stop()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)