### PR TITLE
fix: add RWMutex to protect shared maps from concurrent access

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -30,6 +30,8 @@ type LineClient struct {
 
 	noE2EEGroups map[string]time.Time // chatMid -> when group E2EE failure was cached
 	contactCache map[string]cachedContact
+
+	dataMu sync.RWMutex // protects peerKeys, contactCache, noE2EEGroups
 }
 
 type peerKeyInfo struct {
@@ -100,12 +102,17 @@ func (lc *LineClient) recoverToken(ctx context.Context) error {
 }
 
 func (lc *LineClient) Connect(ctx context.Context) {
+	lc.dataMu.Lock()
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
 	if lc.contactCache == nil {
 		lc.contactCache = make(map[string]cachedContact)
 	}
+	if lc.noE2EEGroups == nil {
+		lc.noE2EEGroups = make(map[string]time.Time)
+	}
+	lc.dataMu.Unlock()
 	lc.reqSeqMu.Lock()
 	if lc.sentReqSeqs == nil {
 		lc.sentReqSeqs = make(map[int]time.Time)

--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -74,10 +74,11 @@ func (lc *LineClient) fetchAndUnwrapGroupKey(ctx context.Context, chatMid string
 }
 
 func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string, error) {
-	if lc.peerKeys == nil {
-		lc.peerKeys = make(map[string]peerKeyInfo)
-	}
-	if cached, ok := lc.peerKeys[mid]; ok {
+	lc.dataMu.RLock()
+	cached, ok := lc.peerKeys[mid]
+	lc.dataMu.RUnlock()
+
+	if ok {
 		// Cached as Letter Sealing off — return error unless TTL expired
 		if cached.noE2EE {
 			if time.Since(cached.checkedAt) < noE2EETTL {
@@ -96,7 +97,9 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 	if err != nil {
 		// Cache negative result so we don't keep hitting the API
 		if line.IsNoUsableE2EEPublicKey(err) {
+			lc.dataMu.Lock()
 			lc.peerKeys[mid] = peerKeyInfo{noE2EE: true, checkedAt: time.Now()}
+			lc.dataMu.Unlock()
 			lc.UserLogin.Bridge.Log.Info().Str("peer", mid).Msg("Peer has Letter Sealing disabled, will send plain text")
 		}
 		return 0, "", err
@@ -106,7 +109,9 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 		return 0, "", err
 	}
 	pk := peerKeyInfo{raw: int(keyID), pub: res.PublicKey}
+	lc.dataMu.Lock()
 	lc.peerKeys[mid] = pk
+	lc.dataMu.Unlock()
 	if lc.E2EE != nil {
 		lc.E2EE.RegisterPeerPublicKey(pk.raw, pk.pub)
 	}
@@ -115,31 +120,31 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 
 // isGroupNoE2EE checks if a group is cached as having no E2EE shared key.
 func (lc *LineClient) isGroupNoE2EE(chatMid string) bool {
-	if lc.noE2EEGroups == nil {
-		return false
-	}
+	lc.dataMu.RLock()
 	checkedAt, ok := lc.noE2EEGroups[chatMid]
+	lc.dataMu.RUnlock()
 	return ok && time.Since(checkedAt) < noE2EETTL
 }
 
 // markGroupNoE2EE caches a group as having no E2EE shared key.
 func (lc *LineClient) markGroupNoE2EE(chatMid string) {
-	if lc.noE2EEGroups == nil {
-		lc.noE2EEGroups = make(map[string]time.Time)
-	}
+	lc.dataMu.Lock()
 	lc.noE2EEGroups[chatMid] = time.Now()
+	lc.dataMu.Unlock()
 }
 
 // clearGroupNoE2EE removes a group from the noE2EE cache (e.g., when we receive encrypted messages).
 func (lc *LineClient) clearGroupNoE2EE(chatMid string) {
+	lc.dataMu.Lock()
 	delete(lc.noE2EEGroups, chatMid)
+	lc.dataMu.Unlock()
 }
 
 func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int) (int, string, error) {
-	if lc.peerKeys == nil {
-		lc.peerKeys = make(map[string]peerKeyInfo)
-	}
-	if cached, ok := lc.peerKeys[mid]; ok && cached.raw == keyID && cached.pub != "" {
+	lc.dataMu.RLock()
+	cached, ok := lc.peerKeys[mid]
+	lc.dataMu.RUnlock()
+	if ok && cached.raw == keyID && cached.pub != "" {
 		if lc.E2EE != nil {
 			lc.E2EE.RegisterPeerPublicKey(cached.raw, cached.pub)
 		}
@@ -164,7 +169,9 @@ func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int
 
 	pk := peerKeyInfo{raw: int(resKeyID), pub: res.PublicKey}
 	// Cache the fetched key so subsequent lookups reuse it.
+	lc.dataMu.Lock()
 	lc.peerKeys[mid] = pk
+	lc.dataMu.Unlock()
 	if lc.E2EE != nil {
 		lc.E2EE.RegisterPeerPublicKey(pk.raw, pk.pub)
 	}
@@ -178,11 +185,14 @@ func (lc *LineClient) ensurePeerKeyForMessage(ctx context.Context, msg *line.Mes
 
 	// If we receive an encrypted message from a peer we cached as noE2EE,
 	// they must have enabled Letter Sealing — invalidate the cache.
-	if lc.peerKeys != nil {
-		if cached, ok := lc.peerKeys[msg.From]; ok && cached.noE2EE {
-			lc.UserLogin.Bridge.Log.Info().Str("peer", msg.From).Msg("Received encrypted message from peer previously cached as noE2EE, invalidating cache")
-			delete(lc.peerKeys, msg.From)
-		}
+	lc.dataMu.RLock()
+	cached, ok := lc.peerKeys[msg.From]
+	lc.dataMu.RUnlock()
+	if ok && cached.noE2EE {
+		lc.UserLogin.Bridge.Log.Info().Str("peer", msg.From).Msg("Received encrypted message from peer previously cached as noE2EE, invalidating cache")
+		lc.dataMu.Lock()
+		delete(lc.peerKeys, msg.From)
+		lc.dataMu.Unlock()
 	}
 
 	// Group messages have a different chunk layout

--- a/pkg/connector/sync.go
+++ b/pkg/connector/sync.go
@@ -280,6 +280,7 @@ func (lc *LineClient) chatToChatInfo(chat *line.Chat, excludeFromTimeline bool) 
 func (lc *LineClient) generateNameFromMembers(members map[string]bool) string {
 	var names []string
 	count := 0
+	lc.dataMu.RLock()
 	for mid := range members {
 		if mid == string(lc.UserLogin.ID) || mid == lc.Mid || strings.HasPrefix(mid, "c") || strings.HasPrefix(mid, "r") {
 			continue
@@ -292,6 +293,7 @@ func (lc *LineClient) generateNameFromMembers(members map[string]bool) string {
 			break
 		}
 	}
+	lc.dataMu.RUnlock()
 
 	finalNames := names
 	if len(names) > 3 {
@@ -420,7 +422,9 @@ func (lc *LineClient) handleOperation(ctx context.Context, op line.Operation) {
 
 	if OperationType(op.Type) == OpContactUpdate {
 		mid := op.Param1
+		lc.dataMu.Lock()
 		delete(lc.contactCache, mid)
+		lc.dataMu.Unlock()
 		contact := lc.getContact(ctx, mid)
 		name := contact.EffectiveDisplayName()
 		lc.UserLogin.Bridge.Log.Info().Str("mid", mid).Str("name", name).Msg("Contact updated")

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -176,7 +176,10 @@ func (lc *LineClient) GetUserInfo(ctx context.Context, ghost *bridgev2.Ghost) (*
 }
 
 func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
-	if cached, ok := lc.contactCache[mid]; ok && time.Since(cached.cachedAt) < contactCacheTTL {
+	lc.dataMu.RLock()
+	cached, cacheHit := lc.contactCache[mid]
+	lc.dataMu.RUnlock()
+	if cacheHit && time.Since(cached.cachedAt) < contactCacheTTL {
 		return cached.Contact
 	}
 
@@ -192,7 +195,9 @@ func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
 		}
 		if err == nil && profile != nil {
 			contact := line.Contact{Mid: mid, DisplayName: profile.DisplayName, PicturePath: profile.PicturePath}
+			lc.dataMu.Lock()
 			lc.contactCache[mid] = cachedContact{Contact: contact, cachedAt: time.Now()}
+			lc.dataMu.Unlock()
 			return contact
 		}
 		return line.Contact{Mid: mid, DisplayName: mid}
@@ -208,7 +213,9 @@ func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
 	}
 	if err == nil && res != nil && res.Contacts != nil {
 		if wrapper, ok := res.Contacts[mid]; ok {
+			lc.dataMu.Lock()
 			lc.contactCache[mid] = cachedContact{Contact: wrapper.Contact, cachedAt: time.Now()}
+			lc.dataMu.Unlock()
 			return wrapper.Contact
 		}
 	}
@@ -225,7 +232,9 @@ func (lc *LineClient) getContact(ctx context.Context, mid string) line.Contact {
 	if err == nil && buddy != nil {
 		lc.UserLogin.Bridge.Log.Debug().Str("mid", mid).Str("display_name", buddy.DisplayName).Str("picture_path", buddy.PicturePath).Msg("Got buddy profile")
 		contact := line.Contact{Mid: mid, DisplayName: buddy.DisplayName, PicturePath: buddy.PicturePath}
+		lc.dataMu.Lock()
 		lc.contactCache[mid] = cachedContact{Contact: contact, cachedAt: time.Now()}
+		lc.dataMu.Unlock()
 		return contact
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `dataMu sync.RWMutex` to `LineClient` to protect `peerKeys`, `contactCache`, and `noE2EEGroups` from concurrent map read/write panics
- Use RLock for cache reads, Lock for cache writes
- Locks are never held during network calls to avoid blocking concurrent goroutines

## Before / After

### Race condition on shared maps

```
BEFORE:
  goroutine A (SSE poll)         goroutine B (syncChats)      goroutine C (API call)
  ╰── read peerKeys[mid]        ╰── write contactCache[mid]  ╰── write peerKeys[mid]
      (no synchronization)           (no synchronization)         (no synchronization)
      ╰── PANIC: concurrent map read and map write

AFTER:
  goroutine A (SSE poll)         goroutine B (syncChats)      goroutine C (API call)
  ╰── dataMu.RLock              ╰── dataMu.Lock              ╰── (network call, no lock)
      ╰── read peerKeys[mid]        ╰── write contactCache       ╰── dataMu.Lock
      ╰── dataMu.RUnlock            ╰── dataMu.Unlock                ╰── write peerKeys
                                                                      ╰── dataMu.Unlock
```

## Test plan
- [ ] Verify no panics under concurrent load (multiple chats syncing + SSE events)
- [ ] Verify contact cache still works (names resolve correctly)
- [ ] Verify peer key negotiation still works (E2EE messages decrypt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)