### PR TITLE
feat: check determineMediaMessageFlow before E2EE media uploads

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,8 +29,15 @@ type LineClient struct {
 	reqSeqMu    sync.Mutex
 	sentReqSeqs map[int]time.Time
 
-	noE2EEGroups map[string]time.Time // chatMid -> when group E2EE failure was cached
-	contactCache map[string]cachedContact
+	noE2EEGroups   map[string]time.Time // chatMid -> when group E2EE failure was cached
+	contactCache   map[string]cachedContact
+	mediaFlowCache map[string]cachedMediaFlow
+}
+
+type cachedMediaFlow struct {
+	flowMap  map[string]int
+	cachedAt time.Time
+	ttl      time.Duration
 }
 
 type peerKeyInfo struct {
@@ -44,6 +52,53 @@ const contactCacheTTL = 1 * time.Hour
 type cachedContact struct {
 	line.Contact
 	cachedAt time.Time
+}
+
+const defaultMediaFlowTTL = 6 * time.Hour
+
+// shouldUseE2EEMediaFlow checks whether the server wants E2EE upload (flow 2)
+// for the given chat and content type. Returns true for E2EE, false for plain.
+// Falls back to true (E2EE) if the server call fails, to preserve existing behavior.
+func (lc *LineClient) shouldUseE2EEMediaFlow(chatMid string, contentType int) bool {
+	if lc.mediaFlowCache == nil {
+		lc.mediaFlowCache = make(map[string]cachedMediaFlow)
+	}
+
+	if cached, ok := lc.mediaFlowCache[chatMid]; ok && time.Since(cached.cachedAt) < cached.ttl {
+		flow, exists := cached.flowMap[strconv.Itoa(contentType)]
+		if exists {
+			return flow == 2
+		}
+		// Content type not in map — default to E2EE
+		return true
+	}
+
+	client := line.NewClient(lc.AccessToken)
+	resp, err := client.DetermineMediaMessageFlow(chatMid)
+	if err != nil {
+		lc.UserLogin.Bridge.Log.Warn().Err(err).Str("chat_mid", chatMid).
+			Msg("Failed to determine media flow, defaulting to E2EE upload")
+		return true
+	}
+
+	ttl := defaultMediaFlowTTL
+	if resp.CacheTTLMillis != "" {
+		if parsed, err := strconv.ParseInt(resp.CacheTTLMillis, 10, 64); err == nil && parsed > 0 {
+			ttl = time.Duration(parsed) * time.Millisecond
+		}
+	}
+
+	lc.mediaFlowCache[chatMid] = cachedMediaFlow{
+		flowMap:  resp.FlowMap,
+		cachedAt: time.Now(),
+		ttl:      ttl,
+	}
+
+	flow, exists := resp.FlowMap[strconv.Itoa(contentType)]
+	if exists {
+		return flow == 2
+	}
+	return true
 }
 
 var _ bridgev2.NetworkAPI = (*LineClient)(nil)

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -54,6 +54,22 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 		contentMetadata["e2eeVersion"] = "2"
 	}
 
+	// For non-text messages, check with the server whether to use E2EE or plain media upload.
+	// This must happen before media processing since it affects the upload path.
+	useE2EEMedia := !plainText
+	if useE2EEMedia && msg.Content.MsgType != event.MsgText {
+		mediaContentType := contentTypeForMsgType(msg.Content.MsgType)
+		if !lc.shouldUseE2EEMediaFlow(portalMid, mediaContentType) {
+			lc.UserLogin.Bridge.Log.Info().
+				Str("portal", portalMid).
+				Int("content_type", mediaContentType).
+				Msg("Server indicates plain media flow for this chat")
+			useE2EEMedia = false
+			plainText = true
+			delete(contentMetadata, "e2eeVersion")
+		}
+	}
+
 	// For plain text, we set lineMsg.Text directly; payload is used only for E2EE.
 	var payload []byte
 	var plainTextBody string // used when plainText == true for text messages
@@ -593,6 +609,21 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 			Timestamp: time.UnixMilli(now),
 		},
 	}, nil
+}
+
+func contentTypeForMsgType(msgType event.MessageType) int {
+	switch msgType {
+	case event.MsgImage:
+		return int(ContentImage)
+	case event.MsgVideo:
+		return int(ContentVideo)
+	case event.MsgAudio:
+		return int(ContentAudio)
+	case event.MsgFile:
+		return int(ContentFile)
+	default:
+		return int(ContentText)
+	}
 }
 
 func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridgev2.MatrixMessageRemove) error {

--- a/pkg/line/methods.go
+++ b/pkg/line/methods.go
@@ -536,3 +536,25 @@ func (c *Client) SendChatRemoved(reqSeq int64, chatMid, lastReadMessageId string
 	_, err := c.callRPC("TalkService", "sendChatRemoved", reqSeq, chatMid, lastReadMessageId, lastReadMessageTime)
 	return err
 }
+
+// DetermineMediaMessageFlow asks the server which upload path to use for media
+// in a given chat. Flow value 2 = E2EE encrypted upload, 1 = plain upload.
+func (c *Client) DetermineMediaMessageFlow(chatMid string) (*MediaMessageFlowResponse, error) {
+	req := map[string]string{"chatMid": chatMid}
+	resp, err := c.callRPC("TalkService", "determineMediaMessageFlow", req)
+	if err != nil {
+		return nil, err
+	}
+	var wrapper struct {
+		Code    int                      `json:"code"`
+		Message string                   `json:"message"`
+		Data    MediaMessageFlowResponse `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &wrapper); err != nil {
+		return nil, fmt.Errorf("failed to parse determineMediaMessageFlow response: %w", err)
+	}
+	if wrapper.Code != 0 {
+		return nil, fmt.Errorf("determineMediaMessageFlow failed: %s", wrapper.Message)
+	}
+	return &wrapper.Data, nil
+}

--- a/pkg/line/structs.go
+++ b/pkg/line/structs.go
@@ -309,3 +309,8 @@ type PageInfoResult struct {
 type ObsInfo struct {
 	CDN string `json:"cdn"`
 }
+
+type MediaMessageFlowResponse struct {
+	FlowMap        map[string]int `json:"flowMap"`
+	CacheTTLMillis string         `json:"cacheTtlMillis"`
+}


### PR DESCRIPTION
⚠️ LINE Chrome Extension v3.7.2

## Summary

- Adds a `determineMediaMessageFlow` API call before media uploads to check whether the server expects E2EE or plain upload for a given chat
- Caches the response per chat using the server-provided TTL (falls back to 6 hours)
- If the API call fails, defaults to E2EE upload to preserve existing behavior
- Only applies to non-text media messages where E2EE was initially negotiated

## Files changed

- `pkg/line/methods.go` — new `DetermineMediaMessageFlow` RPC method
- `pkg/line/structs.go` — new `MediaMessageFlowResponse` struct
- `pkg/connector/client.go` — `shouldUseE2EEMediaFlow` with per-chat caching
- `pkg/connector/send_message.go` — flow check before media processing, `contentTypeForMsgType` helper

## Test report

Tested on home server with 4 chat types, sending mov, txt, png, and text to each:

| Scenario | Result |
|---|---|
| **LSOFF peer** | `plainText` already set from `negotiateE2EEPublicKey` — `determineMediaMessageFlow` correctly skipped. All media sent as plain. |
| **LSON peer** | `determineMediaMessageFlow` called, returned E2EE flow. Media uploaded with E2EE encryption. |
| **LSON-only group** | Group shared key fetched/unwrapped successfully. `determineMediaMessageFlow` confirmed E2EE flow. Media uploaded with E2EE. |
| **Mixed group** | `determineMediaMessageFlow` returned plain flow for all media types (file, image, video) — `"Server indicates plain media flow for this chat"` logged for each. Text message fell back to plain via group key fetch failure (`"Group has no E2EE keys"`). |

**Notes:**
- The change is additive — if `determineMediaMessageFlow` fails, it falls back to existing E2EE behavior
- OBS 400 errors on plain media thumbnail uploads are pre-existing and unrelated to this change

## Test plan

- [x] LSOFF peer: media sent as plain, flow check skipped
- [x] LSON peer: media sent as E2EE, flow check confirms
- [x] LSON-only group: E2EE media with group shared key
- [x] Mixed group: flow check detects plain, media sent as plain
- [x] Text messages unaffected (flow check only applies to media)
- [x] API failure fallback: defaults to E2EE (safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)