### PR TITLE
feat: check getSettings e2eeEnable before E2EE init

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -143,6 +143,30 @@ func (lc *LineClient) Connect(ctx context.Context) {
 		StateEvent: status.StateConnected,
 	})
 
+	// Check server-side E2EE setting before initializing E2EE manager
+	e2eeEnabled := true // default to attempting E2EE
+	settingsClient := line.NewClient(lc.AccessToken)
+	if settings, err := settingsClient.GetSettings(); err != nil {
+		lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to fetch settings, assuming E2EE enabled")
+	} else {
+		e2eeEnabled = settings.E2EEEnable
+		lc.UserLogin.Bridge.Log.Info().Bool("e2ee_enable", settings.E2EEEnable).Msg("Server settings fetched")
+	}
+
+	if !e2eeEnabled {
+		lc.UserLogin.Bridge.Log.Info().Msg("E2EE disabled per server settings, skipping E2EE manager init")
+		lc.E2EE = nil
+	} else {
+		lc.initE2EE()
+	}
+
+	go lc.syncChats(ctx)
+	go lc.syncDMChats(ctx)
+	go lc.prefetchMessages(ctx)
+	go lc.pollLoop(ctx)
+}
+
+func (lc *LineClient) initE2EE() {
 	// Initialize E2EE manager and load keys
 	mgr, err := e2ee.NewManager()
 	if err != nil {
@@ -172,11 +196,6 @@ func (lc *LineClient) Connect(ctx context.Context) {
 			}
 		}
 	}
-
-	go lc.syncChats(ctx)
-	go lc.syncDMChats(ctx)
-	go lc.prefetchMessages(ctx)
-	go lc.pollLoop(ctx)
 }
 
 func (lc *LineClient) tryLogin(ctx context.Context) error {

--- a/pkg/line/methods.go
+++ b/pkg/line/methods.go
@@ -532,6 +532,26 @@ func (c *Client) UnsendMessage(reqSeq int64, messageID string) error {
 	return err
 }
 
+// GetSettings fetches account settings including e2eeEnable.
+func (c *Client) GetSettings() (*Settings, error) {
+	resp, err := c.callRPC("TalkService", "getSettings", 2)
+	if err != nil {
+		return nil, err
+	}
+	var wrapper struct {
+		Code    int      `json:"code"`
+		Message string   `json:"message"`
+		Data    Settings `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &wrapper); err != nil {
+		return nil, fmt.Errorf("failed to parse getSettings response: %w", err)
+	}
+	if wrapper.Code != 0 {
+		return nil, fmt.Errorf("getSettings failed: %s", wrapper.Message)
+	}
+	return &wrapper.Data, nil
+}
+
 func (c *Client) SendChatRemoved(reqSeq int64, chatMid, lastReadMessageId string, lastReadMessageTime int64) error {
 	_, err := c.callRPC("TalkService", "sendChatRemoved", reqSeq, chatMid, lastReadMessageId, lastReadMessageTime)
 	return err

--- a/pkg/line/structs.go
+++ b/pkg/line/structs.go
@@ -311,7 +311,7 @@ type ObsInfo struct {
 }
 
 type Settings struct {
-	E2EEEnable                     bool   `json:"e2eeEnable"`
-	PrivacyAllowSecondaryDeviceLogin bool `json:"privacyAllowSecondaryDeviceLogin"`
-	PreferenceLocale               string `json:"preferenceLocale"`
+	E2EEEnable                       bool   `json:"e2eeEnable"`
+	PrivacyAllowSecondaryDeviceLogin bool   `json:"privacyAllowSecondaryDeviceLogin"`
+	PreferenceLocale                 string `json:"preferenceLocale"`
 }

--- a/pkg/line/structs.go
+++ b/pkg/line/structs.go
@@ -309,3 +309,9 @@ type PageInfoResult struct {
 type ObsInfo struct {
 	CDN string `json:"cdn"`
 }
+
+type Settings struct {
+	E2EEEnable                     bool   `json:"e2eeEnable"`
+	PrivacyAllowSecondaryDeviceLogin bool `json:"privacyAllowSecondaryDeviceLogin"`
+	PreferenceLocale               string `json:"preferenceLocale"`
+}


### PR DESCRIPTION
⚠️ LINE Chrome Extension v3.7.2

## Summary

- Call `TalkService/getSettings` during `Connect()` to check the server-side `e2eeEnable` flag
- If `e2eeEnable: false`, skip E2EE manager initialization entirely (all messages use plaintext)
- Extracted E2EE init into `initE2EE()` for clarity
- Falls back to attempting E2EE if the settings call fails

## Why

The bridge currently relies solely on error 89 during login to detect LSOFF accounts. With the Letter Sealing enforcement rollout (and accounts flapping between states), having a secondary confirmation via `getSettings` makes the detection more robust.

From our traffic captures, the Chrome Extension always calls `getSettings` post-login and checks `e2eeEnable`:
- LSON account: `e2eeEnable: true`
- LSOFF account: `e2eeEnable: false`

## Test plan

- [ ] Login with LSON account → logs `e2ee_enable=true`, E2EE manager initializes normally
- [ ] Login with LSOFF account → logs `e2ee_enable=false`, E2EE manager skipped, all messages plaintext
- [ ] Send media to LSON peer → E2EE encryption works as before
- [ ] Send media to LSOFF peer → plaintext as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
