### PR TITLE
fix: enable Beeper reconnect banner for LINE bridge

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -32,6 +32,12 @@ type LineClient struct {
 	noE2EEGroups   map[string]time.Time // chatMid -> when group E2EE failure was cached
 	contactCache   map[string]cachedContact
 	mediaFlowCache map[string]cachedMediaFlow
+
+	refreshTimer            *time.Timer
+	durationUntilRefreshSec int64
+
+	recoverMu   sync.Mutex
+	recoverTime time.Time
 }
 
 type cachedMediaFlow struct {
@@ -119,10 +125,22 @@ func (lc *LineClient) refreshAndSave(ctx context.Context) error {
 	if res.RefreshToken != "" {
 		lc.RefreshToken = res.RefreshToken
 	}
+	if res.DurationUntilRefreshSec != "" {
+		if d, err := strconv.ParseInt(res.DurationUntilRefreshSec, 10, 64); err == nil {
+			lc.durationUntilRefreshSec = d
+		}
+	}
+
+	// Validate the new token with a lightweight API call before persisting it
+	validationClient := line.NewClient(lc.AccessToken)
+	if _, err := validationClient.GetProfile(); err != nil {
+		return fmt.Errorf("refreshed token failed validation: %w", err)
+	}
 
 	meta := lc.UserLogin.Metadata.(*UserLoginMetadata)
 	meta.AccessToken = lc.AccessToken
 	meta.RefreshToken = lc.RefreshToken
+	meta.DurationUntilRefreshSec = lc.durationUntilRefreshSec
 	err = lc.UserLogin.Save(ctx)
 	if err != nil {
 		lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to save refreshed tokens to DB")
@@ -131,6 +149,42 @@ func (lc *LineClient) refreshAndSave(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// isTokenError returns true if the error indicates the access token is expired,
+// invalid, or the session was logged out from another device.
+// It returns false for E2EE key-specific errors that resemble auth errors.
+func (lc *LineClient) isTokenError(err error) bool {
+	if err == nil {
+		return false
+	}
+	isE2EEGroup := line.IsNoUsableE2EEGroupKey(err)
+	isE2EEPub := line.IsNoUsableE2EEPublicKey(err)
+	if isE2EEGroup || isE2EEPub {
+		return false
+	}
+	isRefresh := lc.isRefreshRequired(err)
+	isLogged := lc.isLoggedOut(err)
+	has401 := strings.Contains(err.Error(), "401")
+	has403 := strings.Contains(err.Error(), "403")
+	return isRefresh || isLogged || has401 || has403
+}
+
+// callWithRecovery creates a LINE API client and calls fn. If the call fails
+// with a token error, it recovers the session and retries once.
+// Returns the (possibly refreshed) client so callers can reuse it.
+func (lc *LineClient) callWithRecovery(ctx context.Context, fn func(*line.Client) error) (*line.Client, error) {
+	client := line.NewClient(lc.AccessToken)
+	err := fn(client)
+	if err != nil && lc.isTokenError(err) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			err = fn(client)
+		} else {
+			lc.UserLogin.Bridge.Log.Warn().Err(errRecover).Msg("callWithRecovery: recovery failed")
+		}
+	}
+	return client, err
 }
 
 func (lc *LineClient) isRefreshRequired(err error) bool {
@@ -143,14 +197,35 @@ func (lc *LineClient) isLoggedOut(err error) bool {
 }
 
 // recoverToken attempts to restore a valid session by refreshing, then re-logging in.
-// Returns nil on success. On failure the caller should send StateBadCredentials.
+// Returns nil on success. On failure it sends StateBadCredentials automatically.
+// Concurrent callers are serialized; if recovery happened within the last 10 seconds
+// the call is a no-op (the token was already refreshed by another goroutine).
 func (lc *LineClient) recoverToken(ctx context.Context) error {
+	lc.recoverMu.Lock()
+	defer lc.recoverMu.Unlock()
+
+	if time.Since(lc.recoverTime) < 10*time.Second {
+		lc.UserLogin.Bridge.Log.Debug().Msg("Skipping token recovery — already recovered recently")
+		return nil
+	}
+
 	if err := lc.refreshAndSave(ctx); err == nil {
 		lc.UserLogin.Bridge.Log.Info().Msg("Token recovered via refresh")
+		lc.scheduleTokenRefresh()
+		lc.recoverTime = time.Now()
 		return nil
 	}
 	lc.UserLogin.Bridge.Log.Info().Msg("Refresh failed, attempting re-login with stored credentials...")
-	return lc.tryLogin(ctx)
+	if err := lc.tryLogin(ctx); err != nil {
+		lc.UserLogin.BridgeState.Send(status.BridgeState{
+			StateEvent: status.StateBadCredentials,
+			Message:    fmt.Sprintf("Token recovery failed: %v", err),
+		})
+		return err
+	}
+	lc.scheduleTokenRefresh()
+	lc.recoverTime = time.Now()
+	return nil
 }
 
 func (lc *LineClient) Connect(ctx context.Context) {
@@ -191,6 +266,8 @@ func (lc *LineClient) Connect(ctx context.Context) {
 		})
 		return
 	}
+
+	lc.scheduleTokenRefresh()
 
 	lc.UserLogin.Bridge.Log.Info().Int("token_len", len(lc.AccessToken)).Msg("LINE client connected; notifying bridge")
 	lc.UserLogin.BridgeState.Send(status.BridgeState{
@@ -293,6 +370,11 @@ func (lc *LineClient) tryLogin(ctx context.Context) error {
 		if res.TokenV3IssueResult.RefreshToken != "" {
 			lc.RefreshToken = res.TokenV3IssueResult.RefreshToken
 		}
+		if res.TokenV3IssueResult.DurationUntilRefreshSec != "" {
+			if d, err := strconv.ParseInt(res.TokenV3IssueResult.DurationUntilRefreshSec, 10, 64); err == nil {
+				lc.durationUntilRefreshSec = d
+			}
+		}
 	}
 	if res.Mid != "" {
 		lc.Mid = res.Mid
@@ -346,7 +428,37 @@ func (lc *LineClient) ensureValidToken(ctx context.Context) error {
 	return lc.tryLogin(ctx)
 }
 
-func (lc *LineClient) Disconnect() {}
+// scheduleTokenRefresh sets a timer to proactively refresh the access token
+// before it expires. The timer fires 5 minutes before the server-reported
+// expiration so the bridge never operates with a stale token.
+func (lc *LineClient) scheduleTokenRefresh() {
+	if lc.durationUntilRefreshSec <= 0 {
+		return
+	}
+	const marginSec = 5 * 60
+	delaySec := lc.durationUntilRefreshSec - marginSec
+	if delaySec < 60 {
+		delaySec = 60
+	}
+	if lc.refreshTimer != nil {
+		lc.refreshTimer.Stop()
+	}
+	lc.refreshTimer = time.AfterFunc(time.Duration(delaySec)*time.Second, func() {
+		lc.UserLogin.Bridge.Log.Info().Int64("delay_sec", delaySec).Msg("Proactive token refresh triggered")
+		if err := lc.refreshAndSave(context.Background()); err != nil {
+			lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Proactive token refresh failed")
+			return
+		}
+		lc.scheduleTokenRefresh()
+	})
+	lc.UserLogin.Bridge.Log.Info().Int64("delay_sec", delaySec).Msg("Scheduled proactive token refresh")
+}
+
+func (lc *LineClient) Disconnect() {
+	if lc.refreshTimer != nil {
+		lc.refreshTimer.Stop()
+	}
+}
 
 func (lc *LineClient) IsLoggedIn() bool { return lc.AccessToken != "" }
 

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -250,10 +250,17 @@ func (lc *LineClient) Connect(ctx context.Context) {
 		if err := lc.tryLogin(ctx); err != nil {
 			lc.UserLogin.BridgeState.Send(status.BridgeState{
 				StateEvent: status.StateBadCredentials,
-				Error:      "line-login-failed",
 				Message:    err.Error(),
 			})
 			return
+		}
+	}
+
+	// Update remote profile so bridge states include the user's name
+	if lc.UserLogin.RemoteProfile.Name == "" {
+		if profile, err := line.NewClient(lc.AccessToken).GetProfile(); err == nil {
+			lc.UserLogin.RemoteName = profile.DisplayName
+			lc.UserLogin.RemoteProfile = status.RemoteProfile{Name: profile.DisplayName}
 		}
 	}
 
@@ -261,7 +268,6 @@ func (lc *LineClient) Connect(ctx context.Context) {
 	if err := lc.ensureValidToken(ctx); err != nil {
 		lc.UserLogin.BridgeState.Send(status.BridgeState{
 			StateEvent: status.StateBadCredentials,
-			Error:      "line-token-expired",
 			Message:    fmt.Sprintf("session expired and could not be restored: %v", err),
 		})
 		return
@@ -337,13 +343,7 @@ func (lc *LineClient) tryLogin(ctx context.Context) error {
 			pin = res.PinCode
 		}
 		if pin != "" {
-			lc.UserLogin.Bridge.Log.Warn().Msg("PIN verification required — check your LINE mobile app to complete re-login")
-			// Send the PIN via bridge state so the user sees it in their Matrix client
-			lc.UserLogin.BridgeState.Send(status.BridgeState{
-				StateEvent: status.StateConnecting,
-				Error:      "line-pin-required",
-				Message:    fmt.Sprintf("Enter this PIN on your LINE mobile app: %s", pin),
-			})
+			lc.UserLogin.Bridge.Log.Warn().Msg("PIN verification required — certificate may be expired")
 		}
 		if res.Verifier == "" {
 			return fmt.Errorf("login requires interaction but no verifier returned")

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -77,16 +77,16 @@ func (lc *LineConnector) GetDBMetaTypes() database.MetaTypes {
 }
 
 type UserLoginMetadata struct {
-	AccessToken       string            `json:"access_token"`
-	RefreshToken      string            `json:"refresh_token,omitempty"`
-	Email             string            `json:"email,omitempty"`
-	Password          string            `json:"password,omitempty"`
-	Certificate       string            `json:"certificate,omitempty"`
-	Mid               string            `json:"mid,omitempty"`
-	EncryptedKeyChain string            `json:"encrypted_key_chain,omitempty"`
-	E2EEPublicKey     string            `json:"e2ee_public_key,omitempty"`
-	E2EEVersion       string            `json:"e2ee_version,omitempty"`
-	E2EEKeyID         string            `json:"e2ee_key_id,omitempty"`
+	AccessToken             string            `json:"access_token"`
+	RefreshToken            string            `json:"refresh_token,omitempty"`
+	Email                   string            `json:"email,omitempty"`
+	Password                string            `json:"password,omitempty"`
+	Certificate             string            `json:"certificate,omitempty"`
+	Mid                     string            `json:"mid,omitempty"`
+	EncryptedKeyChain       string            `json:"encrypted_key_chain,omitempty"`
+	E2EEPublicKey           string            `json:"e2ee_public_key,omitempty"`
+	E2EEVersion             string            `json:"e2ee_version,omitempty"`
+	E2EEKeyID               string            `json:"e2ee_key_id,omitempty"`
 	ExportedKeyMap          map[string]string `json:"exported_key_map,omitempty"`
 	DurationUntilRefreshSec int64             `json:"duration_until_refresh_sec,omitempty"`
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -86,17 +87,19 @@ type UserLoginMetadata struct {
 	E2EEPublicKey     string            `json:"e2ee_public_key,omitempty"`
 	E2EEVersion       string            `json:"e2ee_version,omitempty"`
 	E2EEKeyID         string            `json:"e2ee_key_id,omitempty"`
-	ExportedKeyMap    map[string]string `json:"exported_key_map,omitempty"`
+	ExportedKeyMap          map[string]string `json:"exported_key_map,omitempty"`
+	DurationUntilRefreshSec int64             `json:"duration_until_refresh_sec,omitempty"`
 }
 
 func (lc *LineConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLogin) error {
 	meta := login.Metadata.(*UserLoginMetadata)
 	login.Client = &LineClient{
-		UserLogin:    login,
-		AccessToken:  meta.AccessToken,
-		RefreshToken: meta.RefreshToken,
-		Mid:          meta.Mid,
-		HTTPClient:   &http.Client{Timeout: 10 * time.Second},
+		UserLogin:               login,
+		AccessToken:             meta.AccessToken,
+		RefreshToken:            meta.RefreshToken,
+		Mid:                     meta.Mid,
+		HTTPClient:              &http.Client{Timeout: 10 * time.Second},
+		durationUntilRefreshSec: meta.DurationUntilRefreshSec,
 	}
 	return nil
 }
@@ -338,6 +341,11 @@ func (ll *LineEmailLogin) finishLogin(ctx context.Context, res *line.LoginResult
 	}
 
 	meta := &UserLoginMetadata{AccessToken: token, RefreshToken: refreshToken, Email: ll.Email, Password: ll.Password, Certificate: res.Certificate, Mid: res.Mid}
+	if res.TokenV3IssueResult != nil && res.TokenV3IssueResult.DurationUntilRefreshSec != "" {
+		if d, err := strconv.ParseInt(res.TokenV3IssueResult.DurationUntilRefreshSec, 10, 64); err == nil {
+			meta.DurationUntilRefreshSec = d
+		}
+	}
 	if res.EncryptedKeyChain != "" && res.E2EEPublicKey != "" {
 		meta.EncryptedKeyChain = res.EncryptedKeyChain
 		meta.E2EEPublicKey = res.E2EEPublicKey

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -27,6 +27,15 @@ type LineConnector struct {
 
 var _ bridgev2.NetworkConnector = (*LineConnector)(nil)
 
+func init() {
+	status.BridgeStateHumanErrors.Update(status.BridgeStateErrorMap{
+		"line-recovery-failed": "Your LINE session expired and could not be restored. Please reconnect the bridge.",
+		"line-login-failed":    "LINE login failed. Please reconnect the bridge.",
+		"line-token-expired":   "Your LINE session expired. Please reconnect the bridge.",
+		"line-logged-out":      "You were logged out from LINE (another device logged in). Please reconnect the bridge.",
+	})
+}
+
 func (lc *LineConnector) Init(bridge *bridgev2.Bridge) {
 	lc.br = bridge
 }
@@ -55,7 +64,7 @@ func (lc *LineConnector) GetName() bridgev2.BridgeName {
 		NetworkURL:       "https://line.me",
 		NetworkIcon:      "",
 		NetworkID:        "line",
-		BeeperBridgeType: "github.com/highesttt/matrix-line-messenger",
+		BeeperBridgeType: "line",
 		DefaultPort:      29322,
 	}
 }
@@ -378,9 +387,10 @@ func (ll *LineEmailLogin) finishLogin(ctx context.Context, res *line.LoginResult
 	detectedLineID := networkid.UserLoginID(profile.Mid)
 
 	ul, err := ll.User.NewLogin(ctx, &database.UserLogin{
-		ID:         detectedLineID,
-		RemoteName: displayName,
-		Metadata:   meta,
+		ID:            detectedLineID,
+		RemoteName:    displayName,
+		RemoteProfile: status.RemoteProfile{Name: displayName},
+		Metadata:      meta,
 	}, &bridgev2.NewLoginParams{
 		LoadUserLogin: func(ctx context.Context, login *bridgev2.UserLogin) error {
 			login.Client = &LineClient{

--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -73,7 +73,7 @@ func (lc *LineClient) fetchAndUnwrapGroupKey(ctx context.Context, chatMid string
 	return nil
 }
 
-func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string, error) {
+func (lc *LineClient) ensurePeerKey(ctx context.Context, mid string) (int, string, error) {
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
@@ -93,6 +93,12 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 	}
 	client := line.NewClient(lc.AccessToken)
 	res, err := client.NegotiateE2EEPublicKey(mid)
+	if err != nil && !line.IsNoUsableE2EEPublicKey(err) && lc.isTokenError(err) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			res, err = client.NegotiateE2EEPublicKey(mid)
+		}
+	}
 	if err != nil {
 		// Cache negative result so we don't keep hitting the API
 		if line.IsNoUsableE2EEPublicKey(err) {
@@ -135,7 +141,7 @@ func (lc *LineClient) clearGroupNoE2EE(chatMid string) {
 	delete(lc.noE2EEGroups, chatMid)
 }
 
-func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int) (int, string, error) {
+func (lc *LineClient) ensurePeerKeyByID(ctx context.Context, mid string, keyID int) (int, string, error) {
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)
 	}
@@ -149,6 +155,12 @@ func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int
 	client := line.NewClient(lc.AccessToken)
 	// keyVersion 1
 	res, err := client.GetE2EEPublicKey(mid, 1, keyID)
+	if err != nil && lc.isTokenError(err) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			res, err = client.GetE2EEPublicKey(mid, 1, keyID)
+		}
+	}
 	if err != nil {
 		return 0, "", err
 	}

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -583,7 +583,12 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 	lc.sentReqSeqs[reqSeq] = time.Now()
 	lc.reqSeqMu.Unlock()
 
-	sentMsg, err := client.SendMessage(int64(reqSeq), lineMsg)
+	var sentMsg *line.Message
+	client, err = lc.callWithRecovery(ctx, func(c *line.Client) error {
+		var e error
+		sentMsg, e = c.SendMessage(int64(reqSeq), lineMsg)
+		return e
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -642,8 +647,6 @@ func contentTypeForMsgType(msgType event.MessageType) int {
 }
 
 func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridgev2.MatrixMessageRemove) error {
-	client := line.NewClient(lc.AccessToken)
-
 	reqSeq := int(time.Now().UnixMilli() % 1_000_000_000)
 	lc.reqSeqMu.Lock()
 	if lc.sentReqSeqs == nil {
@@ -652,7 +655,9 @@ func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridge
 	lc.sentReqSeqs[reqSeq] = time.Now()
 	lc.reqSeqMu.Unlock()
 
-	err := client.UnsendMessage(int64(reqSeq), string(msg.TargetMessage.ID))
+	_, err := lc.callWithRecovery(ctx, func(c *line.Client) error {
+		return c.UnsendMessage(int64(reqSeq), string(msg.TargetMessage.ID))
+	})
 	if err != nil && strings.Contains(err.Error(), "message too old") {
 		return bridgev2.WrapErrorInStatus(fmt.Errorf("message too old to unsend on LINE (24h limit)")).
 			WithStatus(event.MessageStatusFail).
@@ -664,8 +669,6 @@ func (lc *LineClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridge
 }
 
 func (lc *LineClient) HandleMatrixLeaveRoom(ctx context.Context, portal *bridgev2.Portal) error {
-	client := line.NewClient(lc.AccessToken)
-
 	reqSeq := int(time.Now().UnixMilli() % 1_000_000_000)
 	lc.reqSeqMu.Lock()
 	if lc.sentReqSeqs == nil {
@@ -674,5 +677,8 @@ func (lc *LineClient) HandleMatrixLeaveRoom(ctx context.Context, portal *bridgev
 	lc.sentReqSeqs[reqSeq] = time.Now()
 	lc.reqSeqMu.Unlock()
 
-	return client.SendChatRemoved(int64(reqSeq), string(portal.ID), "0", 0)
+	_, err := lc.callWithRecovery(ctx, func(c *line.Client) error {
+		return c.SendChatRemoved(int64(reqSeq), string(portal.ID), "0", 0)
+	})
+	return err
 }

--- a/pkg/connector/sync.go
+++ b/pkg/connector/sync.go
@@ -400,7 +400,6 @@ func (lc *LineClient) pollLoop(ctx context.Context) {
 							lc.UserLogin.Bridge.Log.Error().Err(errRecover).Msg("Failed to recover session, stopping poll loop")
 							lc.UserLogin.BridgeState.Send(status.BridgeState{
 								StateEvent: status.StateBadCredentials,
-								Error:      "line-logged-out",
 								Message:    "LINE session was invalidated (logged out by another client). Please re-authenticate the bridge.",
 							})
 							return


### PR DESCRIPTION
⚠️ blocked by https://github.com/highesttt/matrix-line-messenger/pull/99

## Summary
- Remove `Error` codes from `BAD_CREDENTIALS` bridge state sends so Beeper shows the reconnect banner (matches mautrix-signal behavior, gives `ttl=21600` via framework)
- Register LINE error codes in `BridgeStateHumanErrors` for Beeper display
- Populate `RemoteProfile.Name` during Connect and login so Beeper identifies the bridge in banners
- Use short `BeeperBridgeType: "line"` (matches official bridge convention)
- Remove misleading `CONNECTING` state before `BAD_CREDENTIALS` in tryLogin

### Screenshots After Fix

<img width="374" height="232" alt="Screenshot 2026-04-10 at 4 16 26" src="https://github.com/user-attachments/assets/35bd89db-8c40-48bc-8be4-cf5ad60c7fb4" />

<img width="390" height="237" alt="Screenshot 2026-04-10 at 4 16 18" src="https://github.com/user-attachments/assets/8170d30a-8562-40e1-9b59-0a0ef19b2e11" />

### Before / After

\`\`\`
BEFORE                                    AFTER
──────                                    ─────
Bridge sends BAD_CREDENTIALS with:        Bridge sends BAD_CREDENTIALS with:
  error: "line-recovery-failed"             (no error code)
  ttl: 3600                                 ttl: 21600 (set by framework)
  remote_profile: {}                        remote_profile: {"name":"..."}

Beeper: no banner shown                   Beeper: "line disconnected" ✅
\`\`\`

Depends on #99. Extracted from the original #99 as a standalone, easy-to-review PR.

## Test plan
- [x] Verify Beeper shows "line disconnected" reconnect banner when session expires
- [x] Verify \`RemoteProfile.Name\` appears in bridge state — confirmed: \`"remote_profile":{"name":"Caio"}\`
- [x] Verify \`BeeperBridgeType\` is \`"line"\` in bridge info — confirmed: \`"com.beeper.bridge.service":"line"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)