### PR TITLE
feat: add location messages and contact sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,19 @@ Based on the [mautrix-twilio](https://github.com/mautrix/twilio) bridge
 
 ## Features
 
-ℹ️ Works with both [Letter Sealing](readme/LETTER_SEALING.md) `ON` and `OFF` accounts.
-
-- [x] Messages (Text, Images, Videos, Files, and Audio/Voice notes)
+- [x] Messages
+  - [x] Text
+  - [x] Images
+  - [x] Videos
+  - [x] Files
+  - [x] Voice notes
+  - [ ] Audio files
+  - [x] GIFs
+  - [x] Location sharing (receive only)
+  - [x] Contact sharing (receive only)
+    - [x] LINE friend (name only)
+    - [x] Device contact (vCard)
+  - [ ] Mentions
 - [x] Read receipts
 - [x] Reaction support (Receive ONLY)
 - [x] Replies

--- a/pkg/connector/consts.go
+++ b/pkg/connector/consts.go
@@ -19,12 +19,14 @@ const (
 type ContentType int
 
 const (
-	ContentText    ContentType = 0
-	ContentImage   ContentType = 1
-	ContentVideo   ContentType = 2
-	ContentAudio   ContentType = 3
-	ContentSticker ContentType = 7
-	ContentFile    ContentType = 14
+	ContentText     ContentType = 0
+	ContentImage    ContentType = 1
+	ContentVideo    ContentType = 2
+	ContentAudio    ContentType = 3
+	ContentSticker  ContentType = 7
+	ContentContact  ContentType = 13
+	ContentFile     ContentType = 14
+	ContentLocation ContentType = 15
 )
 
 // ToType values for LINE message destinations.

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -789,45 +789,20 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 			}
 
 			// Handle Contact (LINE contact — contentType 13)
+			// LINE only provides displayName and internal MID — no phone/email/LINE ID,
+			// so a vCard would be empty. Show a notice instead.
 			if ContentType(data.ContentType) == ContentContact {
 				displayName := data.ContentMetadata["displayName"]
 				if displayName == "" {
 					displayName = "Unknown"
-				}
-				// Build a minimal vCard for LINE contacts
-				vcard := fmt.Sprintf("BEGIN:VCARD\r\nVERSION:3.0\r\nFN:%s\r\nEND:VCARD\r\n", displayName)
-				fileName := displayName + ".vcf"
-				vcardBytes := []byte(vcard)
-				mxc, file, err := intent.UploadMedia(ctx, portal.MXID, vcardBytes, fileName, "text/vcard")
-				if err != nil {
-					lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to upload LINE contact vCard")
-					return &bridgev2.ConvertedMessage{
-						Parts: []*bridgev2.ConvertedMessagePart{
-							{
-								Type: event.EventMessage,
-								Content: &event.MessageEventContent{
-									MsgType:   event.MsgNotice,
-									Body:      fmt.Sprintf("Shared contact: %s", displayName),
-									RelatesTo: replyRelatesTo,
-								},
-							},
-						},
-					}, nil
 				}
 				return &bridgev2.ConvertedMessage{
 					Parts: []*bridgev2.ConvertedMessagePart{
 						{
 							Type: event.EventMessage,
 							Content: &event.MessageEventContent{
-								MsgType:  event.MsgFile,
-								Body:     fileName,
-								URL:      mxc,
-								File:     file,
-								FileName: fileName,
-								Info: &event.FileInfo{
-									MimeType: "text/vcard",
-									Size:     len(vcardBytes),
-								},
+								MsgType:   event.MsgNotice,
+								Body:      fmt.Sprintf("LINE contact shared: %s. Open LINE to add them.", displayName),
 								RelatesTo: replyRelatesTo,
 							},
 						},

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -760,18 +760,18 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 					}, nil
 				}
 				if data.Location != nil {
-					geoURI := fmt.Sprintf("geo:%f,%f", data.Location.Latitude, data.Location.Longitude)
-					bodyParts := []string{}
+					geoURI := fmt.Sprintf("geo:%.6f,%.6f", data.Location.Latitude, data.Location.Longitude)
+					mapsURL := fmt.Sprintf("https://maps.google.com/maps?q=%.6f%%2C%.6f", data.Location.Latitude, data.Location.Longitude)
+
+					var bodyParts []string
 					if data.Location.Title != "" {
 						bodyParts = append(bodyParts, data.Location.Title)
 					}
 					if data.Location.Address != "" {
 						bodyParts = append(bodyParts, data.Location.Address)
 					}
+					bodyParts = append(bodyParts, mapsURL)
 					body := strings.Join(bodyParts, "\n")
-					if body == "" {
-						body = geoURI
-					}
 					return &bridgev2.ConvertedMessage{
 						Parts: []*bridgev2.ConvertedMessagePart{
 							{
@@ -788,20 +788,46 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 				}
 			}
 
-			// Handle Contact
+			// Handle Contact (LINE contact — contentType 13)
 			if ContentType(data.ContentType) == ContentContact {
 				displayName := data.ContentMetadata["displayName"]
 				if displayName == "" {
 					displayName = "Unknown"
 				}
-				body := fmt.Sprintf("Shared contact: %s", displayName)
+				// Build a minimal vCard for LINE contacts
+				vcard := fmt.Sprintf("BEGIN:VCARD\r\nVERSION:3.0\r\nFN:%s\r\nEND:VCARD\r\n", displayName)
+				fileName := displayName + ".vcf"
+				vcardBytes := []byte(vcard)
+				mxc, file, err := intent.UploadMedia(ctx, portal.MXID, vcardBytes, fileName, "text/vcard")
+				if err != nil {
+					lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to upload LINE contact vCard")
+					return &bridgev2.ConvertedMessage{
+						Parts: []*bridgev2.ConvertedMessagePart{
+							{
+								Type: event.EventMessage,
+								Content: &event.MessageEventContent{
+									MsgType:   event.MsgNotice,
+									Body:      fmt.Sprintf("Shared contact: %s", displayName),
+									RelatesTo: replyRelatesTo,
+								},
+							},
+						},
+					}, nil
+				}
 				return &bridgev2.ConvertedMessage{
 					Parts: []*bridgev2.ConvertedMessagePart{
 						{
 							Type: event.EventMessage,
 							Content: &event.MessageEventContent{
-								MsgType:   event.MsgNotice,
-								Body:      body,
+								MsgType:  event.MsgFile,
+								Body:     fileName,
+								URL:      mxc,
+								File:     file,
+								FileName: fileName,
+								Info: &event.FileInfo{
+									MimeType: "text/vcard",
+									Size:     len(vcardBytes),
+								},
 								RelatesTo: replyRelatesTo,
 							},
 						},
@@ -815,17 +841,58 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 				if displayName == "" {
 					displayName = "Unknown"
 				}
-				body := fmt.Sprintf("Shared contact: %s", displayName)
-				if unwrappedText != "" {
-					body += "\n" + unwrappedText
+				vcard := data.ContentMetadata["vCard"]
+				if vcard == "" {
+					// No vCard data — fall back to text notice
+					body := fmt.Sprintf("Shared contact: %s", displayName)
+					if unwrappedText != "" {
+						body += "\n" + unwrappedText
+					}
+					return &bridgev2.ConvertedMessage{
+						Parts: []*bridgev2.ConvertedMessagePart{
+							{
+								Type: event.EventMessage,
+								Content: &event.MessageEventContent{
+									MsgType:   event.MsgNotice,
+									Body:      body,
+									RelatesTo: replyRelatesTo,
+								},
+							},
+						},
+					}, nil
+				}
+				fileName := displayName + ".vcf"
+				vcardBytes := []byte(vcard)
+				mxc, file, err := intent.UploadMedia(ctx, portal.MXID, vcardBytes, fileName, "text/vcard")
+				if err != nil {
+					lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to upload device contact vCard")
+					return &bridgev2.ConvertedMessage{
+						Parts: []*bridgev2.ConvertedMessagePart{
+							{
+								Type: event.EventMessage,
+								Content: &event.MessageEventContent{
+									MsgType:   event.MsgNotice,
+									Body:      fmt.Sprintf("Shared contact: %s", displayName),
+									RelatesTo: replyRelatesTo,
+								},
+							},
+						},
+					}, nil
 				}
 				return &bridgev2.ConvertedMessage{
 					Parts: []*bridgev2.ConvertedMessagePart{
 						{
 							Type: event.EventMessage,
 							Content: &event.MessageEventContent{
-								MsgType:   event.MsgNotice,
-								Body:      body,
+								MsgType:  event.MsgFile,
+								Body:     fileName,
+								URL:      mxc,
+								File:     file,
+								FileName: fileName,
+								Info: &event.FileInfo{
+									MimeType: "text/vcard",
+									Size:     len(vcardBytes),
+								},
 								RelatesTo: replyRelatesTo,
 							},
 						},

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -25,7 +25,7 @@ import (
 func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 	// Only process known content types; skip system messages (group created, member invited, etc.)
 	switch ContentType(msg.ContentType) {
-	case ContentText, ContentImage, ContentVideo, ContentAudio, ContentSticker, ContentFile:
+	case ContentText, ContentImage, ContentVideo, ContentAudio, ContentSticker, ContentContact, ContentFile, ContentLocation:
 		// supported — continue
 	default:
 		lc.UserLogin.Bridge.Log.Debug().
@@ -744,6 +744,95 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 				}, nil
 			}
 
+			// Handle Location
+			if ContentType(data.ContentType) == ContentLocation {
+				if data.Location == nil {
+					return &bridgev2.ConvertedMessage{
+						Parts: []*bridgev2.ConvertedMessagePart{
+							{
+								Type: event.EventMessage,
+								Content: &event.MessageEventContent{
+									MsgType: event.MsgNotice,
+									Body:    "[Location unavailable]",
+								},
+							},
+						},
+					}, nil
+				}
+				if data.Location != nil {
+					geoURI := fmt.Sprintf("geo:%f,%f", data.Location.Latitude, data.Location.Longitude)
+					bodyParts := []string{}
+					if data.Location.Title != "" {
+						bodyParts = append(bodyParts, data.Location.Title)
+					}
+					if data.Location.Address != "" {
+						bodyParts = append(bodyParts, data.Location.Address)
+					}
+					body := strings.Join(bodyParts, "\n")
+					if body == "" {
+						body = geoURI
+					}
+					return &bridgev2.ConvertedMessage{
+						Parts: []*bridgev2.ConvertedMessagePart{
+							{
+								Type: event.EventMessage,
+								Content: &event.MessageEventContent{
+									MsgType:   event.MsgLocation,
+									Body:      body,
+									GeoURI:    geoURI,
+									RelatesTo: replyRelatesTo,
+								},
+							},
+						},
+					}, nil
+				}
+			}
+
+			// Handle Contact
+			if ContentType(data.ContentType) == ContentContact {
+				displayName := data.ContentMetadata["displayName"]
+				if displayName == "" {
+					displayName = "Unknown"
+				}
+				body := fmt.Sprintf("Shared contact: %s", displayName)
+				return &bridgev2.ConvertedMessage{
+					Parts: []*bridgev2.ConvertedMessagePart{
+						{
+							Type: event.EventMessage,
+							Content: &event.MessageEventContent{
+								MsgType:   event.MsgNotice,
+								Body:      body,
+								RelatesTo: replyRelatesTo,
+							},
+						},
+					},
+				}, nil
+			}
+
+			// Handle device/phone contact shared via ORGCONTP (contentType 0 with vCard)
+			if data.ContentMetadata["ORGCONTP"] == "CONTACT" {
+				displayName := data.ContentMetadata["displayName"]
+				if displayName == "" {
+					displayName = "Unknown"
+				}
+				body := fmt.Sprintf("Shared contact: %s", displayName)
+				if unwrappedText != "" {
+					body += "\n" + unwrappedText
+				}
+				return &bridgev2.ConvertedMessage{
+					Parts: []*bridgev2.ConvertedMessagePart{
+						{
+							Type: event.EventMessage,
+							Content: &event.MessageEventContent{
+								MsgType:   event.MsgNotice,
+								Body:      body,
+								RelatesTo: replyRelatesTo,
+							},
+						},
+					},
+				}, nil
+			}
+
 			// Skip empty/whitespace-only text messages (system messages that fell through)
 			if strings.TrimSpace(unwrappedText) == "" {
 				return nil, nil
@@ -754,6 +843,51 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 				MsgType:   event.MsgText,
 				Body:      unwrappedText,
 				RelatesTo: replyRelatesTo,
+			}
+
+			// Handle mentions in text messages
+			if mentionJSON, ok := data.ContentMetadata["MENTION"]; ok && mentionJSON != "" {
+				type lineMentionEntry struct {
+					S string `json:"S"`
+					E string `json:"E"`
+					M string `json:"M"`
+				}
+				type lineMentionData struct {
+					Mentionees []lineMentionEntry `json:"MENTIONEES"`
+				}
+				var mentionData lineMentionData
+				if err := json.Unmarshal([]byte(mentionJSON), &mentionData); err == nil && len(mentionData.Mentionees) > 0 {
+					textRunes := []rune(unwrappedText)
+					htmlBody := unwrappedText
+
+					// Process from right to left so indices remain valid
+					for i := len(mentionData.Mentionees) - 1; i >= 0; i-- {
+						m := mentionData.Mentionees[i]
+						start, errS := strconv.Atoi(m.S)
+						end, errE := strconv.Atoi(m.E)
+						if errS != nil || errE != nil || start < 0 || end > len(textRunes) || start >= end {
+							continue
+						}
+
+						mentionText := string(textRunes[start:end])
+						ghost, err := lc.UserLogin.Bridge.GetGhostByID(ctx, networkid.UserID(m.M))
+						if err == nil && ghost != nil {
+							mxid := ghost.Intent.GetMXID()
+							// Replace in the HTML body (which uses bytes, not runes)
+							// We need to find the mention text in the HTML body and replace it
+							htmlMention := fmt.Sprintf(`<a href="https://matrix.to/#/%s">%s</a>`, mxid, mentionText)
+							// Use byte offsets from rune positions
+							byteStart := len(string(textRunes[:start]))
+							byteEnd := len(string(textRunes[:end]))
+							htmlBody = htmlBody[:byteStart] + htmlMention + htmlBody[byteEnd:]
+						}
+					}
+
+					if htmlBody != unwrappedText {
+						content.Format = event.FormatHTML
+						content.FormattedBody = htmlBody
+					}
+				}
 			}
 
 			urlRegex := regexp.MustCompile(`(https?://)?([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(/[^\s]*)?`)

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -887,51 +887,6 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 				RelatesTo: replyRelatesTo,
 			}
 
-			// Handle mentions in text messages
-			if mentionJSON, ok := data.ContentMetadata["MENTION"]; ok && mentionJSON != "" {
-				type lineMentionEntry struct {
-					S string `json:"S"`
-					E string `json:"E"`
-					M string `json:"M"`
-				}
-				type lineMentionData struct {
-					Mentionees []lineMentionEntry `json:"MENTIONEES"`
-				}
-				var mentionData lineMentionData
-				if err := json.Unmarshal([]byte(mentionJSON), &mentionData); err == nil && len(mentionData.Mentionees) > 0 {
-					textRunes := []rune(unwrappedText)
-					htmlBody := unwrappedText
-
-					// Process from right to left so indices remain valid
-					for i := len(mentionData.Mentionees) - 1; i >= 0; i-- {
-						m := mentionData.Mentionees[i]
-						start, errS := strconv.Atoi(m.S)
-						end, errE := strconv.Atoi(m.E)
-						if errS != nil || errE != nil || start < 0 || end > len(textRunes) || start >= end {
-							continue
-						}
-
-						mentionText := string(textRunes[start:end])
-						ghost, err := lc.UserLogin.Bridge.GetGhostByID(ctx, networkid.UserID(m.M))
-						if err == nil && ghost != nil {
-							mxid := ghost.Intent.GetMXID()
-							// Replace in the HTML body (which uses bytes, not runes)
-							// We need to find the mention text in the HTML body and replace it
-							htmlMention := fmt.Sprintf(`<a href="https://matrix.to/#/%s">%s</a>`, mxid, mentionText)
-							// Use byte offsets from rune positions
-							byteStart := len(string(textRunes[:start]))
-							byteEnd := len(string(textRunes[:end]))
-							htmlBody = htmlBody[:byteStart] + htmlMention + htmlBody[byteEnd:]
-						}
-					}
-
-					if htmlBody != unwrappedText {
-						content.Format = event.FormatHTML
-						content.FormattedBody = htmlBody
-					}
-				}
-			}
-
 			urlRegex := regexp.MustCompile(`(https?://)?([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(/[^\s]*)?`)
 			if match := urlRegex.FindString(unwrappedText); match != "" {
 				match = strings.TrimRight(match, ".,;:!?")

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -16,7 +15,6 @@ import (
 	"maunium.net/go/mautrix/bridgev2/database"
 	"maunium.net/go/mautrix/bridgev2/networkid"
 	"maunium.net/go/mautrix/event"
-	"maunium.net/go/mautrix/id"
 
 	"github.com/highesttt/matrix-line-messenger/pkg/line"
 )
@@ -77,59 +75,6 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 			payload, err = json.Marshal(map[string]string{"text": msg.Content.Body})
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal text payload: %w", err)
-			}
-		}
-
-		// Handle outbound mentions: parse matrix.to links from HTML body
-		if msg.Content.Format == event.FormatHTML && msg.Content.FormattedBody != "" {
-			mentionRegex := regexp.MustCompile(`<a href="https://matrix\.to/#/(@[^"]+)">([^<]+)</a>`)
-			matches := mentionRegex.FindAllStringSubmatchIndex(msg.Content.FormattedBody, -1)
-			if len(matches) > 0 {
-				type mentionEntry struct {
-					S string `json:"S"`
-					E string `json:"E"`
-					M string `json:"M"`
-				}
-				var mentionees []mentionEntry
-				plainBody := msg.Content.Body
-				plainRunes := []rune(plainBody)
-				searchFrom := 0 // track position to avoid matching same occurrence twice
-
-				for _, match := range matches {
-					mxidStr := msg.Content.FormattedBody[match[2]:match[3]]
-					displayName := msg.Content.FormattedBody[match[4]:match[5]]
-
-					// Resolve Matrix user ID to LINE MID
-					mxid := id.UserID(mxidStr)
-					ghost, gErr := lc.UserLogin.Bridge.GetGhostByMXID(ctx, mxid)
-					if gErr != nil || ghost == nil {
-						continue
-					}
-					lineMID := string(ghost.ID)
-
-					// Find the display name in the plain text body (rune-based), starting from searchFrom
-					displayRunes := []rune(displayName)
-					for idx := searchFrom; idx <= len(plainRunes)-len(displayRunes); idx++ {
-						if string(plainRunes[idx:idx+len(displayRunes)]) == displayName {
-							mentionees = append(mentionees, mentionEntry{
-								S: strconv.Itoa(idx),
-								E: strconv.Itoa(idx + len(displayRunes)),
-								M: lineMID,
-							})
-							searchFrom = idx + len(displayRunes)
-							break
-						}
-					}
-				}
-
-				if len(mentionees) > 0 {
-					mentionData := map[string]interface{}{
-						"MENTIONEES": mentionees,
-					}
-					if mentionJSON, mErr := json.Marshal(mentionData); mErr == nil {
-						contentMetadata["MENTION"] = string(mentionJSON)
-					}
-				}
 			}
 		}
 

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"maunium.net/go/mautrix/bridgev2/database"
 	"maunium.net/go/mautrix/bridgev2/networkid"
 	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
 
 	"github.com/highesttt/matrix-line-messenger/pkg/line"
 )
@@ -75,6 +77,59 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 			payload, err = json.Marshal(map[string]string{"text": msg.Content.Body})
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal text payload: %w", err)
+			}
+		}
+
+		// Handle outbound mentions: parse matrix.to links from HTML body
+		if msg.Content.Format == event.FormatHTML && msg.Content.FormattedBody != "" {
+			mentionRegex := regexp.MustCompile(`<a href="https://matrix\.to/#/(@[^"]+)">([^<]+)</a>`)
+			matches := mentionRegex.FindAllStringSubmatchIndex(msg.Content.FormattedBody, -1)
+			if len(matches) > 0 {
+				type mentionEntry struct {
+					S string `json:"S"`
+					E string `json:"E"`
+					M string `json:"M"`
+				}
+				var mentionees []mentionEntry
+				plainBody := msg.Content.Body
+				plainRunes := []rune(plainBody)
+				searchFrom := 0 // track position to avoid matching same occurrence twice
+
+				for _, match := range matches {
+					mxidStr := msg.Content.FormattedBody[match[2]:match[3]]
+					displayName := msg.Content.FormattedBody[match[4]:match[5]]
+
+					// Resolve Matrix user ID to LINE MID
+					mxid := id.UserID(mxidStr)
+					ghost, gErr := lc.UserLogin.Bridge.GetGhostByMXID(ctx, mxid)
+					if gErr != nil || ghost == nil {
+						continue
+					}
+					lineMID := string(ghost.ID)
+
+					// Find the display name in the plain text body (rune-based), starting from searchFrom
+					displayRunes := []rune(displayName)
+					for idx := searchFrom; idx <= len(plainRunes)-len(displayRunes); idx++ {
+						if string(plainRunes[idx:idx+len(displayRunes)]) == displayName {
+							mentionees = append(mentionees, mentionEntry{
+								S: strconv.Itoa(idx),
+								E: strconv.Itoa(idx + len(displayRunes)),
+								M: lineMID,
+							})
+							searchFrom = idx + len(displayRunes)
+							break
+						}
+					}
+				}
+
+				if len(mentionees) > 0 {
+					mentionData := map[string]interface{}{
+						"MENTIONEES": mentionees,
+					}
+					if mentionJSON, mErr := json.Marshal(mentionData); mErr == nil {
+						contentMetadata["MENTION"] = string(mentionJSON)
+					}
+				}
 			}
 		}
 

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -47,6 +47,7 @@ func (lc *LineClient) GetCapabilities(ctx context.Context, portal *bridgev2.Port
 		ReadReceipts:          true,
 		Delete:                event.CapLevelPartialSupport,
 		DeleteChatForEveryone: true,
+		LocationMessage:       event.CapLevelPartialSupport,
 		File: event.FileFeatureMap{
 			event.MsgImage: {
 				Caption: event.CapLevelRejected,

--- a/pkg/line/structs.go
+++ b/pkg/line/structs.go
@@ -65,6 +65,13 @@ type Operation struct {
 	CreatedTime json.Number `json:"createdTime"`
 }
 
+type MessageLocation struct {
+	Title     string  `json:"title"`
+	Address   string  `json:"address"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
 type Message struct {
 	ID              string            `json:"id"`
 	From            string            `json:"from"`
@@ -76,7 +83,8 @@ type Message struct {
 	HasContent      bool              `json:"hasContent,omitempty"`
 	ContentMetadata map[string]string `json:"contentMetadata"`
 
-	Text string `json:"text,omitempty"`
+	Text     string           `json:"text,omitempty"`
+	Location *MessageLocation `json:"location,omitempty"`
 
 	Chunks []string `json:"chunks,omitempty"`
 


### PR DESCRIPTION
## Summary
- Add support for receiving LINE location messages (contentType 15) with Google Maps link
- Add support for receiving LINE contact shares (contentType 13) as notice with redirect to LINE app
- Add support for receiving device/phone contact shares (ORGCONTP=CONTACT) as downloadable vCard files with "Add to Contacts" button
- Add `ContentContact` (13) and `ContentLocation` (15) content type constants
- Add `MessageLocation` struct to LINE message model
- Advertise `LocationMessage: CapLevelPartialSupport` capability (receive-only)

### Location messages
Incoming LINE locations render with title, address, and a clickable Google Maps link — matching Signal bridge behavior.

### Contact sharing
- **LINE contacts** (contentType 13): Show "LINE contact shared: Name. Open LINE to add them." — LINE only provides display name and internal MID, no phone/email
- **Device contacts** (ORGCONTP=CONTACT with vCard): Upload the full vCard as a `.vcf` file so Beeper shows "Add to Contacts" button — matching WhatsApp/Signal behavior

### Screenshots

![IMG_2165](https://github.com/user-attachments/assets/0d027e05-c4ff-443e-b546-6a097cd3f4f2)

<img width="737" height="635" alt="Screenshot 2026-04-13 at 21 30 34" src="https://github.com/user-attachments/assets/0482cdcb-7516-426d-b109-28cb0e5a784a" />

## Test plan
- [x] Receive location from LINE phone → shows map + title + address + Google Maps link
- [x] Receive LINE contact share → shows notice directing to LINE app
- [x] Receive device contact share with vCard → shows "Add to Contacts" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)