### PR TITLE
revert: undo Chrome Extension version bump (PR #112)

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -372,10 +372,3 @@ func guessToType(mid string) ToType {
 	}
 	return ToUser
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/line/client.go
+++ b/pkg/line/client.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	BaseURL          = "https://line-chrome-gw.line-apps.com/api/talk/thrift/Talk"
-	ExtensionVersion = "3.7.2"
+	ExtensionVersion = "3.7.1"
 	UserAgent        = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
 )
 
@@ -302,7 +302,7 @@ func (c *Client) callRPC(service, method string, args ...interface{}) ([]byte, e
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("x-line-chrome-version", ExtensionVersion)
-	req.Header.Set("x-line-application", "CHROMEOS\t3.7.2\tChrome_OS")
+	req.Header.Set("x-line-application", "CHROMEOS\t3.7.1\tChrome_OS\t1")
 	req.Header.Set("x-lal", "en_US")
 	if c.AccessToken != "" {
 		req.Header.Set("x-line-access", c.AccessToken)
@@ -385,7 +385,7 @@ func (c *Client) postWithHMAC(fullURL string, body []byte) ([]byte, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("x-line-chrome-version", ExtensionVersion)
-	req.Header.Set("x-line-application", "CHROMEOS\t3.7.2\tChrome_OS")
+	req.Header.Set("x-line-application", "CHROMEOS\t3.7.1\tChrome_OS\t1")
 	req.Header.Set("x-lal", "en_US")
 	if c.AccessToken != "" {
 		req.Header.Set("x-line-access", c.AccessToken)
@@ -484,7 +484,7 @@ func (c *Client) UploadOBSPlain(data []byte, oid string, obsType string) error {
 	obsParamsB64 := base64.StdEncoding.EncodeToString(obsParamsJSON)
 
 	req.Header.Set("User-Agent", UserAgent)
-	req.Header.Set("x-line-application", "CHROMEOS\t3.7.2\tChrome_OS")
+	req.Header.Set("x-line-application", "CHROMEOS\t3.7.1\tChrome_OS\t1")
 	req.Header.Set("x-lal", "en_US")
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Obs-Params", obsParamsB64)
@@ -543,7 +543,7 @@ func (c *Client) UploadOBSWithSID(data []byte, sid string) (string, error) {
 	obsParamsB64 := base64.StdEncoding.EncodeToString(obsParamsJSON)
 
 	req.Header.Set("User-Agent", UserAgent)
-	req.Header.Set("x-line-application", "CHROMEOS\t3.7.2\tChrome_OS")
+	req.Header.Set("x-line-application", "CHROMEOS\t3.7.1\tChrome_OS\t1")
 	req.Header.Set("x-lal", "en_US")
 	// OBS expects application/octet-stream for binary uploads
 	req.Header.Set("Content-Type", "application/octet-stream")
@@ -604,7 +604,7 @@ func (c *Client) UploadOBSWithOIDAndSID(data []byte, oid string, sid string) err
 	obsParamsB64 := base64.StdEncoding.EncodeToString(obsParamsJSON)
 
 	req.Header.Set("User-Agent", UserAgent)
-	req.Header.Set("x-line-application", "CHROMEOS\t3.7.2\tChrome_OS")
+	req.Header.Set("x-line-application", "CHROMEOS\t3.7.1\tChrome_OS\t1")
 	req.Header.Set("x-lal", "en_US")
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Obs-Params", obsParamsB64)

--- a/pkg/runner.go
+++ b/pkg/runner.go
@@ -67,7 +67,7 @@ func GetRunner() (*Runner, error) {
 		}
 		clientVersion := os.Getenv("CLIENT_VERSION")
 		if clientVersion == "" {
-			clientVersion = "3.7.2"
+			clientVersion = "3.7.1"
 		}
 
 		rt, err := ltsm.NewRuntime()


### PR DESCRIPTION
## Summary

- Reverts #112 which bumped the Chrome Extension version from 3.7.1 to 3.7.2
- Restores `ExtensionVersion` to `3.7.1`
- Restores the trailing `\t1` segment in `x-line-application` headers
- Restores LTSM runtime default client version to `3.7.1`
- Removes unused `min` function in `pkg/connector/client.go` to fix staticcheck lint failure

## Test plan

- [ ] Bridge connects and authenticates successfully
- [ ] Messages send/receive normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)