### PR TITLE
Adopt LINE Chrome v3.7.2 E2EE key handling

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -173,15 +173,36 @@ func (lc *LineClient) Connect(ctx context.Context) {
 			lc.Mid = meta.Mid
 		}
 	}
-	if lc.AccessToken == "" {
-		if err := lc.tryLogin(ctx); err != nil {
-			lc.UserLogin.BridgeState.Send(status.BridgeState{
-				StateEvent: status.StateBadCredentials,
-				Error:      "line-login-failed",
-				Message:    err.Error(),
-			})
-			return
+	if lc.RefreshToken == "" {
+		if meta, ok := lc.UserLogin.Metadata.(*UserLoginMetadata); ok {
+			lc.RefreshToken = meta.RefreshToken
 		}
+	}
+	if lc.AccessToken == "" {
+		if lc.RefreshToken != "" {
+			if err := lc.refreshAndSave(ctx); err != nil {
+				lc.UserLogin.Bridge.Log.Warn().Err(err).Msg("Failed to refresh missing access token")
+			}
+		}
+		if lc.AccessToken == "" {
+			if err := lc.tryLogin(ctx); err != nil {
+				lc.UserLogin.BridgeState.Send(status.BridgeState{
+					StateEvent: status.StateBadCredentials,
+					Error:      "line-login-failed",
+					Message:    err.Error(),
+				})
+				return
+			}
+		}
+	}
+
+	if lc.AccessToken == "" {
+		lc.UserLogin.BridgeState.Send(status.BridgeState{
+			StateEvent: status.StateBadCredentials,
+			Error:      "line-login-failed",
+			Message:    "no access token available after login recovery",
+		})
+		return
 	}
 
 	// Verify the token is still valid before proceeding

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -377,10 +377,3 @@ func guessToType(mid string) ToType {
 	}
 	return ToUser
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -89,6 +89,17 @@ type UserLoginMetadata struct {
 	ExportedKeyMap    map[string]string `json:"exported_key_map,omitempty"`
 }
 
+func (meta *UserLoginMetadata) CopyFrom(other any) {
+	if meta == nil {
+		return
+	}
+	otherMeta, ok := other.(*UserLoginMetadata)
+	if !ok || otherMeta == nil {
+		return
+	}
+	*meta = *otherMeta
+}
+
 func (lc *LineConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLogin) error {
 	meta := login.Metadata.(*UserLoginMetadata)
 	login.Client = &LineClient{
@@ -349,10 +360,12 @@ func (ll *LineEmailLogin) finishLogin(ctx context.Context, res *line.LoginResult
 		Metadata:   meta,
 	}, &bridgev2.NewLoginParams{
 		LoadUserLogin: func(ctx context.Context, login *bridgev2.UserLogin) error {
+			login.Metadata = meta
 			login.Client = &LineClient{
 				UserLogin:    login,
 				AccessToken:  token,
 				RefreshToken: refreshToken,
+				Mid:          profile.Mid,
 				HTTPClient:   &http.Client{Timeout: 10 * time.Second},
 			}
 			return nil
@@ -360,6 +373,16 @@ func (ll *LineEmailLogin) finishLogin(ctx context.Context, res *line.LoginResult
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user login: %w", err)
+	}
+	if savedMeta, ok := ul.Metadata.(*UserLoginMetadata); ok {
+		savedMeta.AccessToken = token
+		savedMeta.RefreshToken = refreshToken
+		if savedMeta.Mid == "" {
+			savedMeta.Mid = profile.Mid
+		}
+		if err := ul.Save(ctx); err != nil {
+			ul.Bridge.Log.Warn().Err(err).Str("login_id", string(ul.ID)).Msg("Failed to persist login metadata after login")
+		}
 	}
 
 	go ul.Client.Connect(context.Background())

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -1,0 +1,30 @@
+package connector
+
+import "testing"
+
+func TestUserLoginMetadataCopyFromReplacesMetadata(t *testing.T) {
+	target := &UserLoginMetadata{
+		AccessToken:   "old-access",
+		RefreshToken:  "old-refresh",
+		E2EEPublicKey: "old-public",
+	}
+	source := &UserLoginMetadata{
+		AccessToken:    "new-access",
+		RefreshToken:   "new-refresh",
+		Mid:            "Unew",
+		E2EEPublicKey:  "new-public",
+		E2EEKeyID:      "5747884",
+		ExportedKeyMap: map[string]string{"1": "secret"},
+	}
+
+	target.CopyFrom(source)
+
+	if target.AccessToken != source.AccessToken ||
+		target.RefreshToken != source.RefreshToken ||
+		target.Mid != source.Mid ||
+		target.E2EEPublicKey != source.E2EEPublicKey ||
+		target.E2EEKeyID != source.E2EEKeyID ||
+		target.ExportedKeyMap["1"] != "secret" {
+		t.Fatalf("metadata was not copied: %#v", target)
+	}
+}

--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -73,6 +73,75 @@ func (lc *LineClient) fetchAndUnwrapGroupKey(ctx context.Context, chatMid string
 	return nil
 }
 
+func (lc *LineClient) registerAndUnwrapGroupKey(ctx context.Context, client *line.Client, chatMid string) error {
+	if lc.E2EE == nil {
+		return fmt.Errorf("E2EE manager not initialized")
+	}
+	keys, err := client.GetLastE2EEPublicKeys(chatMid)
+	if err != nil && (lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			keys, err = client.GetLastE2EEPublicKeys(chatMid)
+		} else {
+			return fmt.Errorf("failed to recover token before fetching group member keys: %w", errRecover)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("no group member E2EE public keys returned for %s", chatMid)
+	}
+
+	for mid, key := range keys {
+		keyID, err := key.KeyID.Int64()
+		if err != nil {
+			return fmt.Errorf("invalid group member key id for %s: %w", mid, err)
+		}
+		pk := peerKeyInfo{raw: int(keyID), pub: key.PublicKey}
+		if lc.peerKeys == nil {
+			lc.peerKeys = make(map[string]peerKeyInfo)
+		}
+		lc.peerKeys[mid] = pk
+		lc.E2EE.RegisterPeerPublicKey(pk.raw, pk.pub)
+	}
+
+	mids, keyIDs, encryptedKeys, err := lc.E2EE.BuildGroupSharedKeyPayload(chatMid, keys)
+	if err != nil {
+		return err
+	}
+	registered, err := client.RegisterE2EEGroupKey(chatMid, mids, keyIDs, encryptedKeys)
+	if err != nil && (lc.isRefreshRequired(err) || lc.isLoggedOut(err)) {
+		if errRecover := lc.recoverToken(ctx); errRecover == nil {
+			client = line.NewClient(lc.AccessToken)
+			registered, err = client.RegisterE2EEGroupKey(chatMid, mids, keyIDs, encryptedKeys)
+		} else {
+			return fmt.Errorf("failed to recover token before registering group key: %w", errRecover)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if registered == nil {
+		return fmt.Errorf("no group shared key returned after registering %s", chatMid)
+	}
+
+	if _, _, err := lc.ensurePeerKeyByID(ctx, registered.Creator, registered.CreatorKeyID); err != nil {
+		return fmt.Errorf("failed to ensure registered creator key: %w", err)
+	}
+	if _, err := lc.E2EE.UnwrapGroupSharedKey(chatMid, registered); err != nil {
+		return fmt.Errorf("failed to unwrap registered group key: %w", err)
+	}
+
+	lc.clearGroupNoE2EE(chatMid)
+	lc.UserLogin.Bridge.Log.Info().
+		Str("chat_mid", chatMid).
+		Int("members", len(mids)).
+		Int("group_key_id", registered.GroupKeyID).
+		Msg("Registered refreshed group E2EE key")
+	return nil
+}
+
 func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string, error) {
 	if lc.peerKeys == nil {
 		lc.peerKeys = make(map[string]peerKeyInfo)

--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -3,7 +3,10 @@ package connector
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
+
+	"maunium.net/go/mautrix/bridgev2"
 
 	"github.com/highesttt/matrix-line-messenger/pkg/e2ee"
 	"github.com/highesttt/matrix-line-messenger/pkg/line"
@@ -160,9 +163,16 @@ func (lc *LineClient) ensurePeerKey(_ context.Context, mid string) (int, string,
 			return cached.raw, cached.pub, nil
 		}
 	}
+	if raw, pub, ok := lc.peerKeyFromKnownLogin(mid, 0); ok {
+		return raw, pub, nil
+	}
 	client := line.NewClient(lc.AccessToken)
 	res, err := client.NegotiateE2EEPublicKey(mid)
 	if err != nil {
+		if raw, pub, ok := lc.peerKeyFromKnownLogin(mid, 0); ok {
+			lc.UserLogin.Bridge.Log.Debug().Err(err).Str("peer", mid).Int("key_id", raw).Msg("Using stored peer public key after LINE lookup failed")
+			return raw, pub, nil
+		}
 		// Cache negative result so we don't keep hitting the API
 		if line.IsNoUsableE2EEPublicKey(err) {
 			lc.peerKeys[mid] = peerKeyInfo{noE2EE: true, checkedAt: time.Now()}
@@ -214,11 +224,18 @@ func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int
 		}
 		return cached.raw, cached.pub, nil
 	}
+	if raw, pub, ok := lc.peerKeyFromKnownLogin(mid, keyID); ok {
+		return raw, pub, nil
+	}
 
 	client := line.NewClient(lc.AccessToken)
 	// keyVersion 1
 	res, err := client.GetE2EEPublicKey(mid, 1, keyID)
 	if err != nil {
+		if raw, pub, ok := lc.peerKeyFromKnownLogin(mid, keyID); ok {
+			lc.UserLogin.Bridge.Log.Debug().Err(err).Str("peer", mid).Int("key_id", raw).Msg("Using stored peer public key after LINE key-id lookup failed")
+			return raw, pub, nil
+		}
 		return 0, "", err
 	}
 
@@ -238,6 +255,43 @@ func (lc *LineClient) ensurePeerKeyByID(_ context.Context, mid string, keyID int
 		lc.E2EE.RegisterPeerPublicKey(pk.raw, pk.pub)
 	}
 	return pk.raw, pk.pub, nil
+}
+
+func (lc *LineClient) peerKeyFromKnownLogin(mid string, keyID int) (int, string, bool) {
+	if lc.UserLogin == nil || lc.UserLogin.User == nil || mid == "" {
+		return 0, "", false
+	}
+	return lc.peerKeyFromLogins(mid, keyID, lc.UserLogin.User.GetUserLogins())
+}
+
+func (lc *LineClient) peerKeyFromLogins(mid string, keyID int, logins []*bridgev2.UserLogin) (int, string, bool) {
+	for _, login := range logins {
+		if login == nil || string(login.ID) != mid {
+			continue
+		}
+		meta, ok := login.Metadata.(*UserLoginMetadata)
+		if !ok || meta == nil || meta.E2EEPublicKey == "" || meta.E2EEKeyID == "" {
+			return 0, "", false
+		}
+		raw, err := parseKeyID(meta.E2EEKeyID)
+		if err != nil || raw == 0 || (keyID != 0 && raw != keyID) {
+			return 0, "", false
+		}
+		pk := peerKeyInfo{raw: raw, pub: meta.E2EEPublicKey}
+		if lc.peerKeys == nil {
+			lc.peerKeys = make(map[string]peerKeyInfo)
+		}
+		lc.peerKeys[mid] = pk
+		if lc.E2EE != nil {
+			lc.E2EE.RegisterPeerPublicKey(pk.raw, pk.pub)
+		}
+		return pk.raw, pk.pub, true
+	}
+	return 0, "", false
+}
+
+func parseKeyID(raw string) (int, error) {
+	return strconv.Atoi(raw)
 }
 
 func (lc *LineClient) ensurePeerKeyForMessage(ctx context.Context, msg *line.Message) {

--- a/pkg/connector/e2ee_keys_test.go
+++ b/pkg/connector/e2ee_keys_test.go
@@ -1,0 +1,65 @@
+package connector
+
+import (
+	"testing"
+
+	"maunium.net/go/mautrix/bridgev2"
+	"maunium.net/go/mautrix/bridgev2/database"
+	"maunium.net/go/mautrix/bridgev2/networkid"
+)
+
+func TestPeerKeyFromLoginsUsesStoredE2EEPublicKey(t *testing.T) {
+	const (
+		peerMID = "Upeer"
+		keyID   = 5747884
+		pubKey  = "peer-public-key"
+	)
+
+	lc := &LineClient{}
+	raw, pub, ok := lc.peerKeyFromLogins(peerMID, keyID, []*bridgev2.UserLogin{{
+		UserLogin: &database.UserLogin{
+			ID: networkid.UserLoginID(peerMID),
+			Metadata: &UserLoginMetadata{
+				E2EEPublicKey: pubKey,
+				E2EEKeyID:     "5747884",
+			},
+		},
+	}})
+	if !ok {
+		t.Fatal("peerKeyFromLogins did not find stored key")
+	}
+	if raw != keyID || pub != pubKey {
+		t.Fatalf("peer key = (%d, %q), want (%d, %q)", raw, pub, keyID, pubKey)
+	}
+	if lc.peerKeys[peerMID].raw != keyID || lc.peerKeys[peerMID].pub != pubKey {
+		t.Fatalf("cached peer key = %#v", lc.peerKeys[peerMID])
+	}
+}
+
+func TestPeerKeyFromLoginsRejectsMismatchedKeyID(t *testing.T) {
+	lc := &LineClient{}
+	_, _, ok := lc.peerKeyFromLogins("Upeer", 1234, []*bridgev2.UserLogin{{
+		UserLogin: &database.UserLogin{
+			ID: networkid.UserLoginID("Upeer"),
+			Metadata: &UserLoginMetadata{
+				E2EEPublicKey: "peer-public-key",
+				E2EEKeyID:     "5747884",
+			},
+		},
+	}})
+	if ok {
+		t.Fatal("peerKeyFromLogins accepted a mismatched key ID")
+	}
+	if len(lc.peerKeys) != 0 {
+		t.Fatalf("peer key cache was populated: %#v", lc.peerKeys)
+	}
+}
+
+func TestParseKeyIDRejectsMalformedValues(t *testing.T) {
+	if id, err := parseKeyID("5747884"); err != nil || id != 5747884 {
+		t.Fatalf("parseKeyID valid value = (%d, %v)", id, err)
+	}
+	if _, err := parseKeyID("5747884extra"); err == nil {
+		t.Fatal("parseKeyID accepted a partially numeric key ID")
+	}
+}

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -593,6 +593,25 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 	lc.reqSeqMu.Unlock()
 
 	sentMsg, err := client.SendMessage(int64(reqSeq), lineMsg)
+	if err != nil && isGroup && !plainText && line.IsE2EEGroupKeyMismatch(err) {
+		lc.UserLogin.Bridge.Log.Info().
+			Err(err).
+			Str("chat_mid", portalMid).
+			Msg("Encrypted group send used stale member key, registering refreshed group key")
+		if errRotate := lc.registerAndUnwrapGroupKey(ctx, client, portalMid); errRotate != nil {
+			return nil, fmt.Errorf("failed to refresh group E2EE key after member mismatch: %w", errRotate)
+		}
+		if contentType != int(ContentText) {
+			chunks, err = lc.E2EE.EncryptGroupMessageRaw(portalMid, fromMid, contentType, payload)
+		} else {
+			chunks, err = lc.E2EE.EncryptGroupMessage(portalMid, fromMid, msg.Content.Body)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to re-encrypt group message after key refresh: %w", err)
+		}
+		lineMsg.Chunks = chunks
+		sentMsg, err = client.SendMessage(int64(reqSeq), lineMsg)
+	}
 	if err != nil && isGroup && !plainText && line.IsNoUsableE2EEGroupKey(err) {
 		lc.markGroupNoE2EE(portalMid)
 		lc.UserLogin.Bridge.Log.Info().

--- a/pkg/connector/send_message.go
+++ b/pkg/connector/send_message.go
@@ -593,6 +593,36 @@ func (lc *LineClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Mat
 	lc.reqSeqMu.Unlock()
 
 	sentMsg, err := client.SendMessage(int64(reqSeq), lineMsg)
+	if err != nil && isGroup && !plainText && line.IsNoUsableE2EEGroupKey(err) {
+		lc.markGroupNoE2EE(portalMid)
+		lc.UserLogin.Bridge.Log.Info().
+			Err(err).
+			Str("chat_mid", portalMid).
+			Msg("Encrypted group send rejected, retrying as plain text")
+
+		plainText = true
+		delete(contentMetadata, "e2eeVersion")
+		delete(contentMetadata, "OID")
+		delete(contentMetadata, "SID")
+		delete(contentMetadata, "ENC_KM")
+
+		lineMsg.Chunks = nil
+		lineMsg.ContentMetadata = contentMetadata
+		if contentType == int(ContentText) {
+			lineMsg.Text = msg.Content.Body
+			lineMsg.HasContent = false
+		} else {
+			if plainMediaData == nil {
+				plainMediaData = originalMediaData
+			}
+			if plainThumbData == nil {
+				plainThumbData = originalThumbData
+			}
+			lineMsg.HasContent = true
+		}
+
+		sentMsg, err = client.SendMessage(int64(reqSeq), lineMsg)
+	}
 
 	// LINE rejects some file types from the Chrome Extension client.
 	// Retry by wrapping the file in a ZIP archive (matching Chrome Extension behavior).

--- a/pkg/e2ee/manager.go
+++ b/pkg/e2ee/manager.go
@@ -1,6 +1,7 @@
 package e2ee
 
 import (
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -38,6 +39,55 @@ type Manager struct {
 	groupSessionChannels map[string]map[int]map[int]int
 
 	latestGroupKey map[string]int // chatMid -> latest groupKeyId
+}
+
+func (m *Manager) BuildGroupSharedKeyPayload(chatMid string, memberKeys map[string]*line.E2EEPublicKey) ([]string, []int, []string, error) {
+	sharedKey := make([]byte, 32)
+	if _, err := rand.Read(sharedKey); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate group shared key: %w", err)
+	}
+
+	mids := make([]string, 0, len(memberKeys))
+	for mid := range memberKeys {
+		mids = append(mids, mid)
+	}
+	sort.Strings(mids)
+
+	myKeyID := 0
+	m.mu.Lock()
+	if m.myKeyID != 0 {
+		myKeyID = m.myKeyID
+	}
+	m.mu.Unlock()
+	if myKeyID == 0 {
+		return nil, nil, nil, fmt.Errorf("my key not loaded")
+	}
+
+	keyIDs := make([]int, 0, len(mids))
+	encryptedKeys := make([]string, 0, len(mids))
+	for _, mid := range mids {
+		key := memberKeys[mid]
+		if key == nil {
+			return nil, nil, nil, fmt.Errorf("missing member key for %s", mid)
+		}
+		rawKeyID, err := key.KeyID.Int64()
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("invalid member key id for %s: %w", mid, err)
+		}
+		m.RegisterPeerPublicKey(int(rawKeyID), key.PublicKey)
+		chanID, err := m.runner.ChannelCreate(myKeyID, key.PublicKey)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to create group key channel for %s: %w", mid, err)
+		}
+		encryptedKey, err := m.runner.ChannelEncryptV1(chanID, string(sharedKey))
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to wrap group shared key for %s: %w", mid, err)
+		}
+		keyIDs = append(keyIDs, int(rawKeyID))
+		encryptedKeys = append(encryptedKeys, encryptedKey)
+	}
+
+	return mids, keyIDs, encryptedKeys, nil
 }
 
 func NewManager() (*Manager, error) {

--- a/pkg/line/errors.go
+++ b/pkg/line/errors.go
@@ -12,6 +12,17 @@ var (
 	ErrNoUsableE2EEGroupKey  = errors.New("no usable E2EE group key")
 )
 
+// IsE2EEGroupKeyMismatch returns true when LINE rejects a group send because
+// the encrypted message used a group key whose member list is stale.
+func IsE2EEGroupKeyMismatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "\"code\":99") ||
+		strings.Contains(msg, "group key member mismatch")
+}
+
 // IsNoUsableE2EEPublicKey returns true when a peer has Letter Sealing disabled
 // (negotiateE2EEPublicKey returns empty allowedTypes / specVersion -1, or no key data).
 func IsNoUsableE2EEPublicKey(err error) bool {
@@ -24,6 +35,7 @@ func IsNoUsableE2EEPublicKey(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "missing fields (pub=false keyID=-1") ||
 		strings.Contains(msg, "missing fields (pub=false keyID=0") ||
+		strings.Contains(strings.ToLower(msg), "member settings off") ||
 		(strings.Contains(msg, "\"allowedTypes\":[]") && strings.Contains(msg, "\"specVersion\":-1"))
 }
 
@@ -81,6 +93,14 @@ func parseE2EEGroupKeyError(method, message string, rawData json.RawMessage) err
 	talk := parseTalkExceptionData(rawData)
 	if isNoUsableE2EEGroupKeyTalkException(message, talk) {
 		return fmt.Errorf("%w: %s", ErrNoUsableE2EEGroupKey, talk.Reason)
+	}
+	return fmt.Errorf("%s failed: %s", method, message)
+}
+
+func parseE2EEPublicKeyError(method, message string, rawData json.RawMessage) error {
+	talk := parseTalkExceptionData(rawData)
+	if isNoUsableE2EEGroupKeyTalkException(message, talk) {
+		return fmt.Errorf("%w: %s", ErrNoUsableE2EEPublicKey, talk.Reason)
 	}
 	return fmt.Errorf("%s failed: %s", method, message)
 }

--- a/pkg/line/methods.go
+++ b/pkg/line/methods.go
@@ -1,6 +1,8 @@
 package line
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -203,143 +205,80 @@ func (c *Client) NegotiateE2EEPublicKey(mid string) (*E2EEPublicKey, error) {
 }
 
 func parseE2EEPublicKey(rawData []byte) (*E2EEPublicKey, error) {
-	var data map[string]any
-	if err := json.Unmarshal(rawData, &data); err != nil {
-		return nil, err
+	var payload e2eePublicKeyPayload
+	dec := json.NewDecoder(bytes.NewReader(rawData))
+	dec.UseNumber()
+	if err := dec.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("%w: failed to parse key data: %w", ErrNoUsableE2EEPublicKey, err)
 	}
 
-	var findString func(any) string
-	findString = func(v any) string {
-		switch t := v.(type) {
-		case string:
-			return t
-		case map[string]any:
-			for _, val := range t {
-				if s := findString(val); s != "" {
-					return s
-				}
-			}
-		case []any:
-			for _, val := range t {
-				if s := findString(val); s != "" {
-					return s
-				}
-			}
+	key := payload.PublicKey
+	if key == nil && (payload.KeyData != "" || payload.KeyID != "") {
+		key = &e2eePublicKeyData{
+			Version:     payload.Version,
+			KeyID:       payload.KeyID,
+			KeyData:     payload.KeyData,
+			CreatedTime: payload.CreatedTime,
 		}
-		return ""
+	}
+	if key == nil || key.KeyData == "" || key.KeyID == "" {
+		return nil, fmt.Errorf("%w: missing fields (pub=%t keyID=%s raw=%s)", ErrNoUsableE2EEPublicKey, key != nil && key.KeyData != "", keyIDString(key), string(rawData))
+	}
+	if err := validateE2EEPublicKeyData(key.KeyData); err != nil {
+		return nil, fmt.Errorf("%w: invalid key data: %w", ErrNoUsableE2EEPublicKey, err)
 	}
 
-	var findInt64 func(any) int64
-	findInt64 = func(v any) int64 {
-		switch t := v.(type) {
-		case json.Number:
-			if n, err := t.Int64(); err == nil {
-				return n
-			}
-		case float64:
-			return int64(t)
-		case int64:
-			return t
-		case int:
-			return int64(t)
-		case string:
-			if t == "" {
-				return 0
-			}
-			if n, err := strconv.ParseInt(t, 10, 64); err == nil {
-				return n
-			}
-		case map[string]any:
-			for _, val := range t {
-				if n := findInt64(val); n != 0 {
-					return n
-				}
-			}
-		case []any:
-			for _, val := range t {
-				if n := findInt64(val); n != 0 {
-					return n
-				}
-			}
-		}
-		return 0
-	}
-
-	var findBool func(any) bool
-	findBool = func(v any) bool {
-		switch t := v.(type) {
-		case bool:
-			return t
-		case string:
-			b, err := strconv.ParseBool(t)
-			return err == nil && b
-		case map[string]any:
-			for _, val := range t {
-				if b := findBool(val); b {
-					return true
-				}
-			}
-		case []any:
-			for _, val := range t {
-				if b := findBool(val); b {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
-	pub := ""
-	keyID := int64(0)
-	if pk, ok := data["publicKey"].(map[string]any); ok {
-		// Try keyData as a direct string first (most common LINE response shape).
-		switch kd := pk["keyData"].(type) {
-		case string:
-			pub = kd
-		case map[string]any:
-			// Nested object — check known field names deterministically before
-			// falling back to the non-deterministic recursive findString.
-			for _, name := range []string{"keyData", "publicKey", "key", "data", "value"} {
-				if s, ok := kd[name].(string); ok && s != "" {
-					pub = s
-					break
-				}
-			}
-			if pub == "" {
-				pub = findString(kd)
-			}
-		default:
-			// keyData is absent or an unexpected type; findString on the whole pk object.
-			pub = findString(pk)
-		}
-		if keyID == 0 {
-			keyID = findInt64(pk["keyId"])
-		}
-	}
-	if pub == "" {
-		pub = findString(data["publicKey"])
-	}
-	if pub == "" {
-		pub = findString(data)
-	}
-	if keyID == 0 {
-		keyID = findInt64(data["keyId"])
-	}
-	if keyID == 0 {
-		keyID = findInt64(data)
-	}
-	if pub == "" || keyID == 0 {
-		return nil, fmt.Errorf("%w: missing fields (pub=%t keyID=%d raw=%s)", ErrNoUsableE2EEPublicKey, pub != "", keyID, string(rawData))
+	keyID, err := key.KeyID.Int64()
+	if err != nil || keyID == 0 {
+		return nil, fmt.Errorf("%w: invalid key ID %q", ErrNoUsableE2EEPublicKey, key.KeyID)
 	}
 
 	return &E2EEPublicKey{
 		KeyID:        json.Number(strconv.FormatInt(keyID, 10)),
-		PublicKey:    pub,
-		E2EEVersion:  int(findInt64(data["e2eeVersion"])),
-		Expired:      findBool(data["expired"]),
-		CreatedTime:  json.Number(strconv.FormatInt(findInt64(data["createdTime"]), 10)),
-		RenewalCount: int(findInt64(data["renewalCount"])),
+		PublicKey:    key.KeyData,
+		E2EEVersion:  payload.E2EEVersion,
+		Expired:      payload.Expired,
+		CreatedTime:  key.CreatedTime,
+		RenewalCount: payload.RenewalCount,
 	}, nil
+}
+
+type e2eePublicKeyPayload struct {
+	AllowedTypes []int              `json:"allowedTypes"`
+	SpecVersion  int                `json:"specVersion"`
+	PublicKey    *e2eePublicKeyData `json:"publicKey"`
+	Version      int                `json:"version"`
+	KeyID        json.Number        `json:"keyId"`
+	KeyData      string             `json:"keyData"`
+	CreatedTime  json.Number        `json:"createdTime"`
+	E2EEVersion  int                `json:"e2eeVersion"`
+	Expired      bool               `json:"expired"`
+	RenewalCount int                `json:"renewalCount"`
+}
+
+type e2eePublicKeyData struct {
+	Version     int         `json:"version"`
+	KeyID       json.Number `json:"keyId"`
+	KeyData     string      `json:"keyData"`
+	CreatedTime json.Number `json:"createdTime"`
+}
+
+func keyIDString(key *e2eePublicKeyData) string {
+	if key == nil {
+		return "0"
+	}
+	return key.KeyID.String()
+}
+
+func validateE2EEPublicKeyData(keyData string) error {
+	decoded, err := base64.StdEncoding.DecodeString(keyData)
+	if err != nil {
+		return err
+	}
+	if len(decoded) != 32 {
+		return fmt.Errorf("decoded key length %d, want 32", len(decoded))
+	}
+	return nil
 }
 
 func (c *Client) GetE2EEPublicKey(mid string, keyVersion, keyID int) (*E2EEPublicKey, error) {

--- a/pkg/line/methods.go
+++ b/pkg/line/methods.go
@@ -159,6 +159,29 @@ func (c *Client) GetLastE2EEGroupSharedKey(chatMid string) (*E2EEGroupSharedKey,
 	return &data, nil
 }
 
+func (c *Client) RegisterE2EEGroupKey(chatMid string, receiverMids []string, receiverKeyIDs []int, encryptedSharedKeys []string) (*E2EEGroupSharedKey, error) {
+	resp, err := c.callRPC("TalkService", "registerE2EEGroupKey", 1, chatMid, receiverMids, receiverKeyIDs, encryptedSharedKeys)
+	if err != nil {
+		return nil, err
+	}
+	var wrapper struct {
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &wrapper); err != nil {
+		return nil, err
+	}
+	if wrapper.Code != 0 {
+		return nil, parseE2EEGroupKeyError("registerE2EEGroupKey", wrapper.Message, wrapper.Data)
+	}
+	var data E2EEGroupSharedKey
+	if err := json.Unmarshal(wrapper.Data, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
 // NegotiateE2EEPublicKey fetches (or renews) the public key of the person you're talking to (E2EE).
 func (c *Client) NegotiateE2EEPublicKey(mid string) (*E2EEPublicKey, error) {
 	resp, err := c.callRPC("TalkService", "negotiateE2EEPublicKey", mid)
@@ -337,6 +360,38 @@ func (c *Client) GetE2EEPublicKey(mid string, keyVersion, keyID int) (*E2EEPubli
 	}
 
 	return parseE2EEPublicKey(wrapper.Data)
+}
+
+func (c *Client) GetLastE2EEPublicKeys(chatMid string) (map[string]*E2EEPublicKey, error) {
+	resp, err := c.callRPC("TalkService", "getLastE2EEPublicKeys", chatMid)
+	if err != nil {
+		return nil, err
+	}
+	var wrapper struct {
+		Code    int             `json:"code"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &wrapper); err != nil {
+		return nil, err
+	}
+	if wrapper.Code != 0 {
+		return nil, parseE2EEPublicKeyError("getLastE2EEPublicKeys", wrapper.Message, wrapper.Data)
+	}
+
+	var rawKeys map[string]json.RawMessage
+	if err := json.Unmarshal(wrapper.Data, &rawKeys); err != nil {
+		return nil, err
+	}
+	keys := make(map[string]*E2EEPublicKey, len(rawKeys))
+	for mid, rawKey := range rawKeys {
+		key, err := parseE2EEPublicKey(rawKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse E2EE public key for %s: %w", mid, err)
+		}
+		keys[mid] = key
+	}
+	return keys, nil
 }
 
 func (c *Client) SendMessage(reqSeq int64, msg *Message) (*Message, error) {

--- a/pkg/line/protocol_test.go
+++ b/pkg/line/protocol_test.go
@@ -1,0 +1,148 @@
+package line
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type capturedRequest struct {
+	method string
+	path   string
+	body   string
+	header http.Header
+}
+
+type queuedResponse struct {
+	status int
+	body   string
+}
+
+type recordingTransport struct {
+	t         *testing.T
+	responses []queuedResponse
+	requests  []capturedRequest
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		rt.t.Fatalf("failed to read request body: %v", err)
+	}
+	if len(rt.responses) == 0 {
+		rt.t.Fatalf("unexpected request to %s", req.URL.String())
+	}
+	resp := rt.responses[0]
+	rt.responses = rt.responses[1:]
+	rt.requests = append(rt.requests, capturedRequest{
+		method: req.Method,
+		path:   req.URL.Path,
+		body:   string(body),
+		header: req.Header.Clone(),
+	})
+	return &http.Response{
+		StatusCode: resp.status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(resp.body)),
+		Request:    req,
+	}, nil
+}
+
+func TestGetLastE2EEPublicKeysParsesCapturedGroupShape(t *testing.T) {
+	const publicKey = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE="
+	rt := &recordingTransport{
+		t: t,
+		responses: []queuedResponse{
+			{status: 200, body: `{"code":0,"message":"OK","data":{"Upeer":{"version":1,"keyId":5808453,"keyData":"` + publicKey + `","createdTime":"1776353631192"}}}`},
+		},
+	}
+	client := NewClient("access")
+	client.HTTPClient = &http.Client{Transport: rt}
+
+	keys, err := client.GetLastE2EEPublicKeys("Cgroup")
+	if err != nil {
+		t.Fatalf("GetLastE2EEPublicKeys returned error: %v", err)
+	}
+	key := keys["Upeer"]
+	if key == nil {
+		t.Fatal("missing Upeer key")
+	}
+	if key.PublicKey != publicKey || key.KeyID.String() != "5808453" {
+		t.Fatalf("key = %#v", key)
+	}
+	if len(rt.requests) != 1 {
+		t.Fatalf("recorded %d requests, want 1", len(rt.requests))
+	}
+	if rt.requests[0].path != "/api/talk/thrift/Talk/TalkService/getLastE2EEPublicKeys" || rt.requests[0].body != `["Cgroup"]` {
+		t.Fatalf("request = %#v", rt.requests[0])
+	}
+}
+
+func TestRegisterE2EEGroupKeyMatchesCapturedRequestShape(t *testing.T) {
+	rt := &recordingTransport{
+		t: t,
+		responses: []queuedResponse{
+			{status: 200, body: `{"code":0,"message":"OK","data":{"keyVersion":1,"groupKeyId":162718348,"creator":"Ume","creatorKeyId":5747884,"receiver":"Ume","receiverKeyId":5747884,"encryptedSharedKey":"wrapped-self","allowedTypes":[0,1,2,3,14,15],"specVersion":2}}`},
+		},
+	}
+	client := NewClient("access")
+	client.HTTPClient = &http.Client{Transport: rt}
+
+	key, err := client.RegisterE2EEGroupKey(
+		"Cgroup",
+		[]string{"Upeer", "Ume"},
+		[]int{5727582, 5747884},
+		[]string{"wrapped-peer", "wrapped-self"},
+	)
+	if err != nil {
+		t.Fatalf("RegisterE2EEGroupKey returned error: %v", err)
+	}
+	if key.GroupKeyID != 162718348 || key.Creator != "Ume" || key.EncryptedSharedKey != "wrapped-self" {
+		t.Fatalf("key = %#v", key)
+	}
+	if len(rt.requests) != 1 {
+		t.Fatalf("recorded %d requests, want 1", len(rt.requests))
+	}
+	if rt.requests[0].path != "/api/talk/thrift/Talk/TalkService/registerE2EEGroupKey" {
+		t.Fatalf("path = %q", rt.requests[0].path)
+	}
+	wantBody := `[1,"Cgroup",["Upeer","Ume"],[5727582,5747884],["wrapped-peer","wrapped-self"]]`
+	if rt.requests[0].body != wantBody {
+		t.Fatalf("body = %q, want %q", rt.requests[0].body, wantBody)
+	}
+}
+
+func TestGroupE2EEErrorClassificationSeparatesMismatchFromLSOFF(t *testing.T) {
+	memberSettingsOff := errFromString(`API error 400: {"code":10051,"message":"RESPONSE_ERROR","data":{"name":"TalkException","code":98,"reason":"member settings off"}}`)
+	if !IsNoUsableE2EEGroupKey(memberSettingsOff) {
+		t.Fatal("code 98 was not classified as no usable group E2EE key")
+	}
+	if IsE2EEGroupKeyMismatch(memberSettingsOff) {
+		t.Fatal("code 98 was classified as group key mismatch")
+	}
+
+	memberMismatch := errFromString(`API error 400: {"code":10051,"message":"RESPONSE_ERROR","data":{"name":"TalkException","code":99,"reason":"group key member mismatch"}}`)
+	if !IsE2EEGroupKeyMismatch(memberMismatch) {
+		t.Fatal("code 99 was not classified as group key mismatch")
+	}
+	if IsNoUsableE2EEGroupKey(memberMismatch) {
+		t.Fatal("code 99 was classified as no usable group E2EE key")
+	}
+}
+
+func TestParseE2EEPublicKeyRejectsMalformedFallbackData(t *testing.T) {
+	_, err := parseE2EEPublicKey([]byte(`{"publicKey":{"keyId":5747884,"keyData":{"0":"0"}}}`))
+	if err == nil {
+		t.Fatal("parseE2EEPublicKey accepted malformed keyData")
+	}
+	if !IsNoUsableE2EEPublicKey(err) {
+		t.Fatalf("error = %v, want no usable E2EE public key", err)
+	}
+}
+
+type errFromString string
+
+func (e errFromString) Error() string {
+	return string(e)
+}

--- a/pkg/runner.go
+++ b/pkg/runner.go
@@ -491,9 +491,16 @@ func (r *Runner) ChannelEncryptV2(channelID int, to, from string, senderKeyID, r
 
 // ChannelDecryptV1 decrypts ciphertext with channel v1 (ios).
 // Uses pure Go crypto when a Go channel is available.
-func (r *Runner) ChannelDecryptV1(channelID, senderKeyID, receiverKeyID int, ciphertext string) (string, string, error) {
+func (r *Runner) ChannelDecryptV1(channelID, senderKeyID, receiverKeyID int, ciphertext string) (plaintext string, plaintextB64 string, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			plaintext = ""
+			plaintextB64 = ""
+			err = fmt.Errorf("LTSM DecryptV1 panic: %v", recovered)
+		}
+	}()
 
 	ctBytes, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
@@ -525,9 +532,16 @@ func (r *Runner) ChannelDecryptV1(channelID, senderKeyID, receiverKeyID int, cip
 
 // ChannelDecryptV2 decrypts ciphertext with channel v2.
 // Uses pure Go crypto when a Go channel is available (V2 is broken in WASM).
-func (r *Runner) ChannelDecryptV2(channelID int, to, from string, senderKeyID, receiverKeyID, contentType int, ciphertext string) (string, string, error) {
+func (r *Runner) ChannelDecryptV2(channelID int, to, from string, senderKeyID, receiverKeyID, contentType int, ciphertext string) (plaintext string, plaintextB64 string, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			plaintext = ""
+			plaintextB64 = ""
+			err = fmt.Errorf("LTSM DecryptV2 panic: %v", recovered)
+		}
+	}()
 
 	ctBytes, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {


### PR DESCRIPTION
## Summary
This adopts the LINE Chrome Extension v3.7.2 post-login E2EE key-handling behavior captured from Chrome. The main new protocol surfaces are `getLastE2EEPublicKeys` and `registerE2EEGroupKey`, which were not part of the previous v3.7.1-era bridge behavior.

- Matches the LINE Chrome extension behavior for mixed Letter Sealing groups by falling back to plaintext when LINE reports no usable group E2EE key.
- Refreshes group E2EE keys when LINE reports a group member mismatch, then retries the encrypted send with the newly registered group key.
- Recovers from LTSM decrypt panics as structured errors instead of letting malformed or unsupported key material crash the bridge path.
- Uses persisted login E2EE public-key metadata as a local peer-key source when LINE cannot return the bridge user's own key.
- Adds focused protocol and connector tests for the captured group E2EE request/error shapes.

Related to #121.

For details of the sanitized Chrome capture evidence, see https://github.com/clins1994/matrix-line-messenger/blob/line-v372-lson-capture-evidence/readme/LSON_CAPTURE_EVIDENCE.md

Scope boundary: this PR starts after auth has completed and the bridge has login E2EE metadata. QR/auth session establishment is handled in #124; this PR covers runtime message encryption and key recovery after login.

## Before
```mermaid
flowchart TD
    A[Authenticated LINE session] --> B[Matrix message to LINE group]
    B --> C[Bridge tries existing group E2EE key]
    C --> D[getE2EEGroupSharedKey]
    D --> E{LINE response}
    E -->|shared key exists| F[Encrypt and send]
    E -->|member LS off / no key| G[Send fails]
    F --> H{sendMessage response}
    H -->|group key member mismatch| I[Send fails]

    J[Need own or peer public key] --> K[negotiateE2EEPublicKey / getE2EEPublicKey]
    K -->|LINE cannot return own key| L[Peer key unavailable]

    M[Inbound encrypted message] --> N[LTSM decrypt]
    N -->|panic on unsupported key material| O[Bridge path panics]
```

## After
```mermaid
flowchart TD
    A[Authenticated LINE session] --> B[Matrix message to LINE group]
    B --> C[Bridge tries group E2EE]
    C --> D[getE2EEGroupSharedKey]
    D --> E{LINE response}
    E -->|shared key exists| F[Encrypt and send]
    E -->|member LS off / no key| P[Mark group as no E2EE]
    P --> Q[Retry plaintext]
    F --> G{sendMessage response}
    G -->|ok| Z[Delivered]
    G -->|group key member mismatch| R[getLastE2EEPublicKeys]
    R --> S[Build refreshed shared-key payload]
    S --> T[registerE2EEGroupKey]
    T --> U[Unwrap refreshed group key]
    U --> V[Re-encrypt and retry]
    V --> Z

    W[Need own or peer public key] --> X[Use LINE lookup]
    X -->|lookup fails for known bridge login| Y[Use persisted login E2EE public key metadata]
    Y --> F

    M[Inbound encrypted message] --> N[LTSM decrypt with panic recovery]
    N -->|unsupported key material| O[Return decrypt error, keep bridge alive]
```

## QA Report
- `go test ./...`
- Manual LSON group capture: created group, sent encrypted message, added another LSON user, sent again, and verified Chrome performs public-key fetch plus group-key registration around member changes.
- Manual LSOFF group capture: adding an LS-off member caused Chrome to send plaintext, matching the fallback implemented here.
- Checked PR contents for request captures and secrets; no raw capture files, tokens, cookies, HMAC values, certificates, Matrix IDs, LINE MIDs, or message text from live captures are included.
