### PR TITLE
Remove VOLUME /data directive from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ COPY --from=builder /build/matrix-line /usr/bin/matrix-line
 COPY ./docker-run.sh /docker-run.sh
 RUN chmod +x /docker-run.sh
 ENV BRIDGEV2=1
-VOLUME /data
 WORKDIR /data
 
 CMD ["/docker-run.sh"]


### PR DESCRIPTION
## Summary

Removes `VOLUME /data` from the Dockerfile. The bridge stores critical persistent state at `/data` (config.yaml, sh-line.db with portal mappings + LINE message-id history, E2EE Megolm keys), so any operator deploying this bridge needs to explicitly provide a persistent mount at that path. The `VOLUME` directive doesn't help that case — it only kicks in when no mount is configured, in which case Docker silently creates an anonymous volume that gets orphaned on every redeploy.

## Why it matters

The `VOLUME` directive *takes precedence over* a downstream orchestrator's intended mount when the orchestrator's mount-binding step happens after image start (or fails silently). We hit this in production with a self-hosted Coolify v4 deployment: the orchestrator's runtime `--volume` flag was being silently dropped at deploy, but `VOLUME /data` always fired — so every redeploy got a fresh anonymous volume. Result: bridge ran, but with empty `/data` → "no config found" → entrypoint writes template → exit → restart loop.

The workaround we ran for a while was a per-redeploy `sudo cp` of the bbctl-generated `config.yaml` from a host-side directory into the new anon-volume hash. Awful: the volume hash changes every deploy, sh-line.db gets reset, and re-login creates duplicate Matrix rooms.

The proper fix downstream is using the orchestrator's named-volume mechanism — but that only works if `VOLUME /data` is *not* present, since otherwise Docker's auto-anon-volume overrides the named-volume mount.

## What this PR changes

- One-line delete: `VOLUME /data` (previously line 35 of Dockerfile)
- `WORKDIR /data` is preserved (the directory is still created + used as working directory)

## What this PR does NOT change

- No runtime change for users who already provide a mount at `/data` (the recommended pattern). They were never relying on the anon-volume fallback anyway.
- No change to the bridge binary, entrypoint script, or any documentation about persistence requirements.

## Testing

Built + deployed on a self-hosted Coolify v4 instance:

- An orchestrator-managed named volume mounts cleanly at `/data` (no longer overridden by anon volume)
- `config.yaml`, `registration.yaml`, `sh-line.db`, and `logs/` persist across redeploys
- Bridge starts in `UNCONFIGURED` state on first run, transitions to logged-in after Beeper Desktop login flow
- Matrix↔LINE round-trip verified

## Alternative considered

Documenting the persistent-mount requirement in the README without removing the directive. Rejected because the directive's silent-override behavior with downstream orchestrators is worse than not having any documentation — operators who don't read every line of the README and rely on their orchestrator's volume management get state loss without any error message.

---

Happy to revise / split / drop if you'd prefer a different approach.
