### PR TITLE
[REFERENCE] Fix Beeper LINE group creation wiring

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"go.mau.fi/util/configupgrade"
+	"go.mau.fi/util/dbutil"
 
 	"maunium.net/go/mautrix/bridgev2"
 	"maunium.net/go/mautrix/bridgev2/database"
@@ -24,6 +26,8 @@ type LineConnector struct {
 	br *bridgev2.Bridge
 }
 
+const beeperLineLoginID networkid.UserLoginID = "sh-line"
+
 var _ bridgev2.NetworkConnector = (*LineConnector)(nil)
 
 func (lc *LineConnector) Init(bridge *bridgev2.Bridge) {
@@ -35,7 +39,82 @@ func (lc *LineConnector) Start(ctx context.Context) error {
 	if !ok {
 		return fmt.Errorf("matrix connector does not implement MatrixConnectorWithServer")
 	}
-	return nil
+	return lc.migrateLegacyLoginID(ctx)
+}
+
+func (lc *LineConnector) migrateLegacyLoginID(ctx context.Context) error {
+	migrate := func(ctx context.Context) error {
+		var legacyCount int
+		err := lc.br.DB.QueryRow(
+			ctx,
+			"SELECT COUNT(*) FROM user_login WHERE bridge_id=$1 AND id<>$2",
+			lc.br.DB.BridgeID, beeperLineLoginID,
+		).Scan(&legacyCount)
+		if err != nil {
+			return fmt.Errorf("failed to count legacy LINE logins: %w", err)
+		} else if legacyCount == 0 {
+			return nil
+		} else if legacyCount > 1 {
+			return fmt.Errorf("refusing to collapse %d LINE logins into %s", legacyCount, beeperLineLoginID)
+		}
+
+		var existingStableCount int
+		err = lc.br.DB.QueryRow(
+			ctx,
+			"SELECT COUNT(*) FROM user_login WHERE bridge_id=$1 AND id=$2",
+			lc.br.DB.BridgeID, beeperLineLoginID,
+		).Scan(&existingStableCount)
+		if err != nil {
+			return fmt.Errorf("failed to check stable LINE login ID: %w", err)
+		} else if existingStableCount > 0 {
+			return nil
+		}
+
+		var legacyID networkid.UserLoginID
+		err = lc.br.DB.QueryRow(
+			ctx,
+			"SELECT id FROM user_login WHERE bridge_id=$1 AND id<>$2 LIMIT 1",
+			lc.br.DB.BridgeID, beeperLineLoginID,
+		).Scan(&legacyID)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil
+			}
+			return fmt.Errorf("failed to find legacy LINE login: %w", err)
+		}
+
+		lc.br.Log.Info().
+			Str("old_login_id", string(legacyID)).
+			Str("new_login_id", string(beeperLineLoginID)).
+			Msg("Migrating LINE login ID")
+
+		updates := []struct {
+			name  string
+			query string
+		}{
+			{"user_login", "UPDATE user_login SET id=$2 WHERE bridge_id=$1 AND id=$3"},
+			{"user_portal.login_id", "UPDATE user_portal SET login_id=$2 WHERE bridge_id=$1 AND login_id=$3"},
+			{"user_portal.portal_receiver", "UPDATE user_portal SET portal_receiver=$2 WHERE bridge_id=$1 AND portal_receiver=$3"},
+			{"portal.receiver", "UPDATE portal SET receiver=$2 WHERE bridge_id=$1 AND receiver=$3"},
+			{"portal.parent_receiver", "UPDATE portal SET parent_receiver=$2 WHERE bridge_id=$1 AND parent_receiver=$3"},
+			{"portal.relay_login_id", "UPDATE portal SET relay_login_id=$2 WHERE relay_bridge_id=$1 AND relay_login_id=$3"},
+			{"message.room_receiver", "UPDATE message SET room_receiver=$2 WHERE bridge_id=$1 AND room_receiver=$3"},
+			{"reaction.room_receiver", "UPDATE reaction SET room_receiver=$2 WHERE bridge_id=$1 AND room_receiver=$3"},
+			{"backfill_task.portal_receiver", "UPDATE backfill_task SET portal_receiver=$2 WHERE bridge_id=$1 AND portal_receiver=$3"},
+			{"backfill_task.user_login_id", "UPDATE backfill_task SET user_login_id=$2 WHERE bridge_id=$1 AND user_login_id=$3"},
+		}
+		for _, update := range updates {
+			if _, err = lc.br.DB.Exec(ctx, update.query, lc.br.DB.BridgeID, beeperLineLoginID, legacyID); err != nil {
+				return fmt.Errorf("failed to migrate %s from legacy LINE login ID: %w", update.name, err)
+			}
+		}
+		return nil
+	}
+
+	if lc.br.DB.Dialect == dbutil.SQLite {
+		return lc.br.DB.DoSQLiteTransactionWithoutForeignKeys(ctx, migrate)
+	}
+	return lc.br.DB.DoTxn(ctx, nil, migrate)
 }
 
 func (lc *LineConnector) GetBridgeInfoVersion() (info, capabilities int) {
@@ -363,10 +442,8 @@ func (ll *LineEmailLogin) finishLogin(ctx context.Context, res *line.LoginResult
 
 	ll.fetchLoginKeys(res, meta, client)
 
-	detectedLineID := networkid.UserLoginID(profile.Mid)
-
 	ul, err := ll.User.NewLogin(ctx, &database.UserLogin{
-		ID:         detectedLineID,
+		ID:         beeperLineLoginID,
 		RemoteName: displayName,
 		Metadata:   meta,
 	}, &bridgev2.NewLoginParams{

--- a/pkg/connector/creategroup.go
+++ b/pkg/connector/creategroup.go
@@ -51,20 +51,20 @@ func (lc *LineClient) CreateGroup(ctx context.Context, params *bridgev2.GroupCre
 		Int("participants", len(participantMids)).
 		Msg("LINE group chat created")
 
-	// Cache the member list so auto-registration can fall back to it
-	// when GetChats withMembers returns empty data.
+	// Newly created LINE groups keep invited users pending until they accept.
+	// Group-key registration must match the active LINE member list, so cache
+	// only our own MID here.
 	lc.cacheMu.Lock()
 	if lc.groupMemberCache == nil {
 		lc.groupMemberCache = make(map[string][]string)
 	}
-	lc.groupMemberCache[chat.ChatMid] = participantMids
+	lc.groupMemberCache[chat.ChatMid] = []string{lc.Mid}
 	lc.cacheMu.Unlock()
 
-	// Register E2EE group key so members can decrypt group messages.
-	// This is best-effort: if E2EE isn't available for a member we skip them,
-	// and if the entire registration fails we log a warning without aborting.
-	if lc.E2EE != nil && len(participantMids) > 0 {
-		if err := lc.registerGroupKey(ctx, chat.ChatMid, participantMids); err != nil {
+	// Register E2EE group key so messages can be sent while invitees are still pending.
+	// This is best-effort: if registration fails we log a warning without aborting.
+	if lc.E2EE != nil && lc.Mid != "" {
+		if err := lc.registerGroupKey(ctx, chat.ChatMid, []string{lc.Mid}); err != nil {
 			lc.UserLogin.Bridge.Log.Warn().Err(err).
 				Str("chat_mid", chat.ChatMid).
 				Msg("Failed to register E2EE group key, continuing without E2EE")
@@ -128,70 +128,100 @@ func (lc *LineClient) CreateGroup(ctx context.Context, params *bridgev2.GroupCre
 
 // registerGroupKey generates a random 32-byte group key, wraps it for each member
 // using ECDH + AES-256-CBC, and registers it with the LINE server so all members
-// can decrypt group messages. The bridge user's own MID is excluded since the
-// creator already has the group key.
+// can decrypt group messages.
 func (lc *LineClient) registerGroupKey(ctx context.Context, chatMid string, members []string) error {
-	// Exclude the bridge user's own MID — the creator already has the group key.
-	otherMembers := make([]string, 0, len(members))
-	for _, mid := range members {
-		if mid != lc.Mid {
-			otherMembers = append(otherMembers, mid)
+	if lc.E2EE == nil {
+		return fmt.Errorf("E2EE manager not initialized")
+	}
+	myRawKeyID, myPublicKey, err := lc.E2EE.MyPublicKey()
+	if err != nil {
+		return fmt.Errorf("missing own E2EE key: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(members)+1)
+	normalizedMembers := make([]string, 0, len(members)+1)
+	for _, mid := range append(members, lc.Mid) {
+		if mid == "" {
+			continue
 		}
+		lowerMid := strings.ToLower(mid)
+		if strings.HasPrefix(lowerMid, "c") || strings.HasPrefix(lowerMid, "r") {
+			continue
+		}
+		if _, ok := seen[mid]; ok {
+			continue
+		}
+		seen[mid] = struct{}{}
+		normalizedMembers = append(normalizedMembers, mid)
 	}
-	if len(otherMembers) == 0 {
-		return fmt.Errorf("no other members to register group key for")
+	if len(normalizedMembers) == 0 {
+		return fmt.Errorf("no members to register group key for")
 	}
-	members = otherMembers
+	members = normalizedMembers
 
 	client := line.NewClient(lc.AccessToken)
 
 	// Fetch current E2EE public keys for all other members as a batch. If the batch
 	// call fails (e.g. server 500 for a specific member), fall back to fetching
 	// each member's key individually via NegotiateE2EEPublicKey.
-	pubKeysReq := line.GetLastE2EEPublicKeysRequest{
-		ChatMid: chatMid,
-		Members: members,
-	}
-	pubKeys, err := client.GetLastE2EEPublicKeys(pubKeysReq)
-	if err != nil {
-		if lc.isRefreshRequired(err) || lc.isLoggedOut(err) {
-			if errRecover := lc.recoverToken(ctx); errRecover == nil {
-				client = line.NewClient(lc.AccessToken)
-				pubKeys, err = client.GetLastE2EEPublicKeys(pubKeysReq)
-			}
+	peerMembers := make([]string, 0, len(members))
+	for _, mid := range members {
+		if mid != lc.Mid {
+			peerMembers = append(peerMembers, mid)
 		}
 	}
-	if err != nil {
-		// Batch call failed — try individual key negotiation per member
-		lc.UserLogin.Bridge.Log.Warn().Err(err).
-			Str("chat_mid", chatMid).
-			Int("members", len(members)).
-			Msg("Batch GetLastE2EEPublicKeys failed, falling back to per-member NegotiateE2EEPublicKey")
-		pubKeys = make(map[string]line.E2EEPeerPublicKey)
-		for _, mid := range members {
-			res, nErr := client.NegotiateE2EEPublicKey(mid)
-			if nErr != nil {
-				if line.IsNoUsableE2EEPublicKey(nErr) {
-					lc.UserLogin.Bridge.Log.Debug().Str("member", mid).Msg("Member has Letter Sealing disabled, skipping")
-					continue
+	pubKeys := map[string]line.E2EEPeerPublicKey{
+		lc.Mid: {KeyID: myRawKeyID, KeyData: myPublicKey},
+	}
+	pubKeysReq := line.GetLastE2EEPublicKeysRequest{
+		ChatMid: chatMid,
+		Members: peerMembers,
+	}
+	if len(peerMembers) > 0 {
+		peerPubKeys, err := client.GetLastE2EEPublicKeys(pubKeysReq)
+		if err != nil {
+			if lc.isRefreshRequired(err) || lc.isLoggedOut(err) {
+				if errRecover := lc.recoverToken(ctx); errRecover == nil {
+					client = line.NewClient(lc.AccessToken)
+					peerPubKeys, err = client.GetLastE2EEPublicKeys(pubKeysReq)
 				}
-				if lc.isRefreshRequired(nErr) || lc.isLoggedOut(nErr) {
-					if errRecover := lc.recoverToken(ctx); errRecover == nil {
-						client = line.NewClient(lc.AccessToken)
-						res, nErr = client.NegotiateE2EEPublicKey(mid)
+			}
+		}
+		if err == nil {
+			for mid, pk := range peerPubKeys {
+				pubKeys[mid] = pk
+			}
+		} else {
+			// Batch call failed — try individual key negotiation per member
+			lc.UserLogin.Bridge.Log.Warn().Err(err).
+				Str("chat_mid", chatMid).
+				Int("members", len(peerMembers)).
+				Msg("Batch GetLastE2EEPublicKeys failed, falling back to per-member NegotiateE2EEPublicKey")
+			for _, mid := range peerMembers {
+				res, nErr := client.NegotiateE2EEPublicKey(mid)
+				if nErr != nil {
+					if line.IsNoUsableE2EEPublicKey(nErr) {
+						lc.UserLogin.Bridge.Log.Debug().Str("member", mid).Msg("Member has Letter Sealing disabled, skipping")
+						continue
+					}
+					if lc.isRefreshRequired(nErr) || lc.isLoggedOut(nErr) {
+						if errRecover := lc.recoverToken(ctx); errRecover == nil {
+							client = line.NewClient(lc.AccessToken)
+							res, nErr = client.NegotiateE2EEPublicKey(mid)
+						}
+					}
+					if nErr != nil {
+						lc.UserLogin.Bridge.Log.Warn().Err(nErr).Str("member", mid).Msg("Failed to negotiate key for member, skipping")
+						continue
 					}
 				}
+				keyID, nErr := res.KeyID.Int64()
 				if nErr != nil {
-					lc.UserLogin.Bridge.Log.Warn().Err(nErr).Str("member", mid).Msg("Failed to negotiate key for member, skipping")
+					lc.UserLogin.Bridge.Log.Warn().Err(nErr).Str("member", mid).Msg("Failed to parse key ID, skipping")
 					continue
 				}
+				pubKeys[mid] = line.E2EEPeerPublicKey{KeyID: int(keyID), KeyData: res.PublicKey}
 			}
-			keyID, nErr := res.KeyID.Int64()
-			if nErr != nil {
-				lc.UserLogin.Bridge.Log.Warn().Err(nErr).Str("member", mid).Msg("Failed to parse key ID, skipping")
-				continue
-			}
-			pubKeys[mid] = line.E2EEPeerPublicKey{KeyID: int(keyID), KeyData: res.PublicKey}
 		}
 	}
 
@@ -202,34 +232,44 @@ func (lc *LineClient) registerGroupKey(ctx context.Context, chatMid string, memb
 		return fmt.Errorf("failed to generate group key: %w", err)
 	}
 
-	// Wrap the group key for each member that has a public key
+	// LINE expects the registration member list to match the chat member list.
+	// Members without usable E2EE keys stay in the payload with empty key slots.
 	apiMembers := make([]string, 0, len(members))
 	keyIds := make([]int, 0, len(members))
 	encryptedKeys := make([]string, 0, len(members))
 
+	validKeyCount := 0
 	for _, mid := range members {
+		apiMembers = append(apiMembers, mid)
+
 		pk, ok := pubKeys[mid]
 		if !ok {
-			lc.UserLogin.Bridge.Log.Debug().Str("member", mid).Msg("No E2EE public key for member, skipping")
+			lc.UserLogin.Bridge.Log.Debug().Str("member", mid).Msg("No E2EE public key for member, registering empty key slot")
+			keyIds = append(keyIds, 0)
+			encryptedKeys = append(encryptedKeys, "")
 			continue
 		}
 		if pk.KeyData == "" {
-			lc.UserLogin.Bridge.Log.Debug().Str("member", mid).Int("key_id", pk.KeyID).Msg("Empty public key data for member, skipping")
+			lc.UserLogin.Bridge.Log.Debug().Str("member", mid).Int("key_id", pk.KeyID).Msg("Empty public key data for member, registering empty key slot")
+			keyIds = append(keyIds, pk.KeyID)
+			encryptedKeys = append(encryptedKeys, "")
 			continue
 		}
 
 		encryptedKey, err := lc.E2EE.WrapGroupKeyForMember(pk.KeyData, groupKeyID)
 		if err != nil {
-			lc.UserLogin.Bridge.Log.Warn().Err(err).Str("member", mid).Msg("Failed to wrap group key for member, skipping")
+			lc.UserLogin.Bridge.Log.Warn().Err(err).Str("member", mid).Msg("Failed to wrap group key for member, registering empty key slot")
+			keyIds = append(keyIds, pk.KeyID)
+			encryptedKeys = append(encryptedKeys, "")
 			continue
 		}
 
-		apiMembers = append(apiMembers, mid)
 		keyIds = append(keyIds, pk.KeyID)
 		encryptedKeys = append(encryptedKeys, encryptedKey)
+		validKeyCount++
 	}
 
-	if len(apiMembers) == 0 {
+	if validKeyCount == 0 {
 		return fmt.Errorf("no members with valid E2EE keys")
 	}
 

--- a/pkg/connector/e2ee_keys.go
+++ b/pkg/connector/e2ee_keys.go
@@ -161,9 +161,9 @@ func (lc *LineClient) clearGroupNoE2EE(chatMid string) {
 	delete(lc.noE2EEGroups, chatMid)
 }
 
-// getChatMemberMIDs fetches the member and invitee MIDs for a group chat via GetChats.
-// Invitees are included because group key registration must happen before they accept,
-// otherwise the key won't be available when they start sending messages.
+// getChatMemberMIDs fetches active member MIDs for a group chat via GetChats.
+// Pending invitees must not be included in registerE2EEGroupKey: LINE rejects
+// the payload unless it matches the current active member count.
 func (lc *LineClient) getChatMemberMIDs(ctx context.Context, chatMid string) ([]string, error) {
 	client := line.NewClient(lc.AccessToken)
 	chats, err := client.GetChats([]string{chatMid}, true, true)
@@ -189,9 +189,6 @@ func (lc *LineClient) getChatMemberMIDs(ctx context.Context, chatMid string) ([]
 	for mid := range chat.Extra.GroupExtra.MemberMids {
 		seen[mid] = struct{}{}
 	}
-	for mid := range chat.Extra.GroupExtra.InviteeMids {
-		seen[mid] = struct{}{}
-	}
 	// Always include the bridge user's own MID since we're definitely a member
 	if _, ok := seen[lc.Mid]; !ok {
 		seen[lc.Mid] = struct{}{}
@@ -201,7 +198,7 @@ func (lc *LineClient) getChatMemberMIDs(ctx context.Context, chatMid string) ([]
 		mids = append(mids, mid)
 	}
 	if len(mids) == 0 {
-		return nil, fmt.Errorf("chat %s has no members or invitees", chatMid)
+		return nil, fmt.Errorf("chat %s has no active members", chatMid)
 	}
 
 	// Cache the successful result for fallback use.
@@ -223,9 +220,10 @@ func (lc *LineClient) autoRegisterGroupKey(ctx context.Context, chatMid string) 
 		return fmt.Errorf("getChatMemberMIDs: %w", err)
 	}
 
-	// If getChatMemberMIDs returned only ourself, the server likely returned
-	// an empty MemberMids map (known LINE API issue). Fall back to cached
-	// member list from CreateGroup or a prior successful fetch.
+	// If getChatMemberMIDs returned only ourself, the server may have returned
+	// an empty MemberMids map (known LINE API issue). Fall back only to a cached
+	// active LINE member list. Matrix room members may include pending LINE
+	// invitees and will make registerE2EEGroupKey fail with member count mismatch.
 	if len(members) == 1 && members[0] == lc.Mid {
 		lc.cacheMu.Lock()
 		cached, ok := lc.groupMemberCache[chatMid]
@@ -234,20 +232,6 @@ func (lc *LineClient) autoRegisterGroupKey(ctx context.Context, chatMid string) 
 			lc.UserLogin.Bridge.Log.Warn().Str("chat_mid", chatMid).
 				Msg("GetChats returned only self MID, falling back to cached member list")
 			members = cached
-		}
-	}
-
-	// Last resort: query Matrix room members via the bridge API.
-	if len(members) == 1 && members[0] == lc.Mid {
-		matrixMembers, err := lc.getGroupMemberMIDsViaMatrix(ctx, chatMid)
-		if err != nil {
-			lc.UserLogin.Bridge.Log.Warn().Err(err).Str("chat_mid", chatMid).
-				Msg("Matrix member fallback also failed")
-		} else if len(matrixMembers) > 1 {
-			lc.UserLogin.Bridge.Log.Warn().Str("chat_mid", chatMid).
-				Int("members", len(matrixMembers)).
-				Msg("GetChats returned only self MID, falling back to Matrix room members")
-			members = matrixMembers
 		}
 	}
 

--- a/pkg/connector/sync.go
+++ b/pkg/connector/sync.go
@@ -233,57 +233,54 @@ func (lc *LineClient) chatToChatInfo(chat *line.Chat, excludeFromTimeline bool) 
 		},
 	}
 
-		if chat.Extra.GroupExtra != nil {
-			if chat.Extra.GroupExtra.CreatorMid == lc.Mid {
-				members[0].PowerLevel = ptr.Ptr(100)
-			}
-			// If the bridge user is not a full member but is an invitee, mark as invite
-			_, isMember := chat.Extra.GroupExtra.MemberMids[lc.Mid]
-			if !isMember {
-				_, isInvitee := chat.Extra.GroupExtra.InviteeMids[lc.Mid]
-				if isInvitee {
-					members[0].Membership = event.MembershipInvite
-				}
-			}
-
-			// Populate group member cache for fallback use when GetChats
-			// returns empty MemberMids (known LINE API issue).
-			allMemberMids := make([]string, 0, len(chat.Extra.GroupExtra.MemberMids))
-			for m := range chat.Extra.GroupExtra.MemberMids {
-				if m == lc.Mid || m == string(lc.UserLogin.ID) || strings.HasPrefix(m, "c") || strings.HasPrefix(m, "r") {
-					continue
-				}
-				allMemberMids = append(allMemberMids, m)
-				members = append(members, bridgev2.ChatMember{
-					EventSender: bridgev2.EventSender{
-						Sender: makeUserID(m),
-					},
-					Membership: event.MembershipJoin,
-				})
-			}
-			for m := range chat.Extra.GroupExtra.InviteeMids {
-				if m == lc.Mid || m == string(lc.UserLogin.ID) || strings.HasPrefix(m, "c") || strings.HasPrefix(m, "r") {
-					continue
-				}
-				allMemberMids = append(allMemberMids, m)
-				members = append(members, bridgev2.ChatMember{
-					EventSender: bridgev2.EventSender{
-						Sender: makeUserID(m),
-					},
-					Membership: event.MembershipInvite,
-				})
-			}
-
-			cachedMids := make([]string, 0, len(allMemberMids)+1)
-			cachedMids = append(cachedMids, lc.Mid)
-			cachedMids = append(cachedMids, allMemberMids...)
-			lc.cacheMu.Lock()
-			if lc.groupMemberCache == nil {
-				lc.groupMemberCache = make(map[string][]string)
-			}
-			lc.groupMemberCache[chat.ChatMid] = cachedMids
-			lc.cacheMu.Unlock()
+	if chat.Extra.GroupExtra != nil {
+		if chat.Extra.GroupExtra.CreatorMid == lc.Mid {
+			members[0].PowerLevel = ptr.Ptr(100)
 		}
+		// If the bridge user is not a full member but is an invitee, mark as invite
+		_, isMember := chat.Extra.GroupExtra.MemberMids[lc.Mid]
+		if !isMember {
+			_, isInvitee := chat.Extra.GroupExtra.InviteeMids[lc.Mid]
+			if isInvitee {
+				members[0].Membership = event.MembershipInvite
+			}
+		}
+
+		// Populate group member cache for fallback use when GetChats
+		// returns empty MemberMids (known LINE API issue).
+		activeMemberMids := make([]string, 0, len(chat.Extra.GroupExtra.MemberMids)+1)
+		activeMemberMids = append(activeMemberMids, lc.Mid)
+		for m := range chat.Extra.GroupExtra.MemberMids {
+			if m == lc.Mid || m == string(lc.UserLogin.ID) || strings.HasPrefix(m, "c") || strings.HasPrefix(m, "r") {
+				continue
+			}
+			activeMemberMids = append(activeMemberMids, m)
+			members = append(members, bridgev2.ChatMember{
+				EventSender: bridgev2.EventSender{
+					Sender: makeUserID(m),
+				},
+				Membership: event.MembershipJoin,
+			})
+		}
+		for m := range chat.Extra.GroupExtra.InviteeMids {
+			if m == lc.Mid || m == string(lc.UserLogin.ID) || strings.HasPrefix(m, "c") || strings.HasPrefix(m, "r") {
+				continue
+			}
+			members = append(members, bridgev2.ChatMember{
+				EventSender: bridgev2.EventSender{
+					Sender: makeUserID(m),
+				},
+				Membership: event.MembershipInvite,
+			})
+		}
+
+		lc.cacheMu.Lock()
+		if lc.groupMemberCache == nil {
+			lc.groupMemberCache = make(map[string][]string)
+		}
+		lc.groupMemberCache[chat.ChatMid] = activeMemberMids
+		lc.cacheMu.Unlock()
+	}
 
 	name := chat.ChatName
 	if name == "" && chat.Extra.GroupExtra != nil {

--- a/pkg/e2ee/manager.go
+++ b/pkg/e2ee/manager.go
@@ -67,6 +67,15 @@ func (m *Manager) MyKeyIDs() (rawID int, keyID int, err error) {
 	return m.myRawKeyID, m.myKeyID, nil
 }
 
+func (m *Manager) MyPublicKey() (rawID int, publicKey string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.myRawKeyID == 0 || m.myPublicB64 == "" {
+		return 0, "", fmt.Errorf("my key not loaded")
+	}
+	return m.myRawKeyID, m.myPublicB64, nil
+}
+
 func (m *Manager) InitStorage(wrappedNonce, kdf1, kdf2 string) error {
 	return m.runner.StorageInit(wrappedNonce, kdf1, kdf2)
 }


### PR DESCRIPTION
## Summary

This fixes the Beeper-side wiring needed for LINE group creation and first sends from newly-created groups.

## What was missing

- Beeper calls the bridge provisioning API with the stable login ID `sh-line`, but the bridge was storing the LINE MID as the `user_login.id`. That made group creation look like it targeted a missing login.
- LINE group-key registration was using pending invitees as if they were active group members. Newly created LINE groups only contain the creator until invitees accept, so LINE rejected registration with `member count mismatch` and outbound messages failed with `group key is not registered`.

## Changes

- Store new LINE logins as `sh-line` and migrate existing single-login databases to that ID while keeping the real LINE MID in metadata for LINE API calls.
- Register LINE E2EE group keys using the active LINE member list only, while preserving pending invitees as Matrix/Beeper invites.
- Include the bridge account's own E2EE public key when registering group keys.

## Validation

- Rebuilt and restarted with `docker compose build matrix-line` and `docker compose up -d matrix-line`.
- Verified group creation from Beeper, LINE-side pending invites, and successful Beeper-to-LINE sending after the active-member group-key fix.