### PR TITLE
Fix avatar removal sync

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -68,6 +68,18 @@ type cachedContact struct {
 
 const defaultMediaFlowTTL = 6 * time.Hour
 
+func (lc *LineClient) avatarFromPicturePath(picturePath string) *bridgev2.Avatar {
+	if picturePath == "" {
+		return &bridgev2.Avatar{Remove: true}
+	}
+	return &bridgev2.Avatar{
+		ID: networkid.AvatarID(picturePath),
+		Get: func(ctx context.Context) ([]byte, error) {
+			return lc.GetAvatar(ctx, networkid.AvatarID(picturePath))
+		},
+	}
+}
+
 // shouldUseE2EEMediaFlow checks whether the server wants E2EE upload (flow 2)
 // for the given chat and content type. Returns true for E2EE, false for plain.
 // Falls back to true (E2EE) if the server call fails, to preserve existing behavior.

--- a/pkg/connector/sync.go
+++ b/pkg/connector/sync.go
@@ -55,17 +55,6 @@ func (lc *LineClient) syncDMChats(ctx context.Context) {
 		}
 
 		contact := lc.getContact(ctx, mid)
-		var avatar *bridgev2.Avatar
-		if contact.PicturePath != "" {
-			picturePath := contact.PicturePath
-			avatar = &bridgev2.Avatar{
-				ID: networkid.AvatarID(picturePath),
-				Get: func(ctx context.Context) ([]byte, error) {
-					return lc.GetAvatar(ctx, networkid.AvatarID(picturePath))
-				},
-			}
-		}
-
 		dmType := database.RoomTypeDM
 		chatName := contact.EffectiveDisplayName()
 		portalKey := networkid.PortalKey{ID: makePortalID(mid), Receiver: lc.UserLogin.ID}
@@ -78,7 +67,7 @@ func (lc *LineClient) syncDMChats(ctx context.Context) {
 			ChatInfo: &bridgev2.ChatInfo{
 				Type:   &dmType,
 				Name:   &chatName,
-				Avatar: avatar,
+				Avatar: lc.avatarFromPicturePath(contact.PicturePath),
 				Members: &bridgev2.ChatMemberList{
 					IsFull:                     true,
 					ExcludeChangesFromTimeline: true,
@@ -215,16 +204,6 @@ func (lc *LineClient) syncChats(ctx context.Context) {
 }
 
 func (lc *LineClient) chatToChatInfo(ctx context.Context, chat *line.Chat, excludeFromTimeline bool) *bridgev2.ChatInfo {
-	var avatar *bridgev2.Avatar
-	if chat.PicturePath != "" {
-		avatar = &bridgev2.Avatar{
-			ID: networkid.AvatarID(chat.PicturePath),
-			Get: func(ctx context.Context) ([]byte, error) {
-				return lc.GetAvatar(ctx, networkid.AvatarID(chat.PicturePath))
-			},
-		}
-	}
-
 	members := []bridgev2.ChatMember{
 		{
 			EventSender: bridgev2.EventSender{
@@ -332,7 +311,7 @@ func (lc *LineClient) chatToChatInfo(ctx context.Context, chat *line.Chat, exclu
 	return &bridgev2.ChatInfo{
 		Type:   &ct,
 		Name:   &name,
-		Avatar: avatar,
+		Avatar: lc.avatarFromPicturePath(chat.PicturePath),
 		Members: &bridgev2.ChatMemberList{
 			IsFull:                     true,
 			Members:                    members,
@@ -699,17 +678,8 @@ func (lc *LineClient) handleOperation(ctx context.Context, op line.Operation) {
 			ghost.UpdateInfo(ctx, &bridgev2.UserInfo{
 				Identifiers: []string{mid},
 				Name:        &name,
+				Avatar:      lc.avatarFromPicturePath(contact.PicturePath),
 			})
-		}
-		var avatar *bridgev2.Avatar
-		if contact.PicturePath != "" {
-			picturePath := contact.PicturePath
-			avatar = &bridgev2.Avatar{
-				ID: networkid.AvatarID(picturePath),
-				Get: func(ctx context.Context) ([]byte, error) {
-					return lc.GetAvatar(ctx, networkid.AvatarID(picturePath))
-				},
-			}
 		}
 		dmType := database.RoomTypeDM
 		portalKey := networkid.PortalKey{ID: makePortalID(mid), Receiver: lc.UserLogin.ID}
@@ -722,7 +692,7 @@ func (lc *LineClient) handleOperation(ctx context.Context, op line.Operation) {
 			ChatInfo: &bridgev2.ChatInfo{
 				Type:   &dmType,
 				Name:   &name,
-				Avatar: avatar,
+				Avatar: lc.avatarFromPicturePath(contact.PicturePath),
 			},
 		})
 		lc.refreshGroupsForContact(ctx, mid)
@@ -1062,16 +1032,6 @@ func (lc *LineClient) syncSingleChat(ctx context.Context, op line.Operation) {
 
 	portalKey := networkid.PortalKey{ID: makePortalID(chat.ChatMid), Receiver: lc.UserLogin.ID}
 
-	var avatar *bridgev2.Avatar
-	if chat.PicturePath != "" {
-		avatar = &bridgev2.Avatar{
-			ID: networkid.AvatarID(chat.PicturePath),
-			Get: func(ctx context.Context) ([]byte, error) {
-				return lc.GetAvatar(ctx, networkid.AvatarID(chat.PicturePath))
-			},
-		}
-	}
-
 	// Use ChatInfoChange to only update avatar (and other non-name metadata).
 	// Name updates are handled by handleGroupRename from contentType=18 messages,
 	// which has the correct new name from LOC_ARGS.
@@ -1084,7 +1044,7 @@ func (lc *LineClient) syncSingleChat(ctx context.Context, op line.Operation) {
 		},
 		ChatInfoChange: &bridgev2.ChatInfoChange{
 			ChatInfo: &bridgev2.ChatInfo{
-				Avatar: avatar,
+				Avatar: lc.avatarFromPicturePath(chat.PicturePath),
 			},
 		},
 	})

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -152,21 +152,12 @@ func (lc *LineClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) 
 	}
 
 	contact := lc.getContact(ctx, string(portal.ID))
-	var avatar *bridgev2.Avatar
-	if contact.PicturePath != "" {
-		avatar = &bridgev2.Avatar{
-			ID: networkid.AvatarID(contact.PicturePath),
-			Get: func(ctx context.Context) ([]byte, error) {
-				return lc.GetAvatar(ctx, networkid.AvatarID(contact.PicturePath))
-			},
-		}
-	}
 	dmType := database.RoomTypeDM
 	chatName := contact.EffectiveDisplayName()
 	return &bridgev2.ChatInfo{
 		Type:   &dmType,
 		Name:   &chatName,
-		Avatar: avatar,
+		Avatar: lc.avatarFromPicturePath(contact.PicturePath),
 		Members: &bridgev2.ChatMemberList{
 			IsFull: true,
 			Members: []bridgev2.ChatMember{
@@ -192,20 +183,11 @@ func (lc *LineClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) 
 
 func (lc *LineClient) GetUserInfo(ctx context.Context, ghost *bridgev2.Ghost) (*bridgev2.UserInfo, error) {
 	contact := lc.getContact(ctx, string(ghost.ID))
-	var avatar *bridgev2.Avatar
-	if contact.PicturePath != "" {
-		avatar = &bridgev2.Avatar{
-			ID: networkid.AvatarID(contact.PicturePath),
-			Get: func(ctx context.Context) ([]byte, error) {
-				return lc.GetAvatar(ctx, networkid.AvatarID(contact.PicturePath))
-			},
-		}
-	}
 	name := contact.EffectiveDisplayName()
 	return &bridgev2.UserInfo{
 		Identifiers: []string{string(ghost.ID)},
 		Name:        &name,
-		Avatar:      avatar,
+		Avatar:      lc.avatarFromPicturePath(contact.PicturePath),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Treat empty LINE picture paths as explicit bridgev2 avatar removals instead of no-op updates.
- Reuse one helper for chat, DM, contact, and ghost avatar info.

## Root cause

LINE returns an empty PicturePath after a profile/group icon is deleted. The bridge was passing Avatar: nil in that case, but bridgev2 interprets nil as “leave the existing Matrix avatar unchanged”.

## Validation

- docker compose build matrix-line

Fixes #145

### Step 1 - see it on beeper with icon

<img width="499" height="75" alt="Screenshot 2026-05-17 at 16 40 35" src="https://github.com/user-attachments/assets/1406149c-5cf0-44e7-99bf-dafb02584b6d" />

### Step 2 - remove icon via line

<img width="353" height="529" alt="Screenshot 2026-05-17 at 16 51 45" src="https://github.com/user-attachments/assets/d7a3ac8b-b15c-4590-a48f-659ca8040d3f" />

### Step 3 - see it on line without icon

<img width="301" height="521" alt="Screenshot 2026-05-17 at 16 51 51" src="https://github.com/user-attachments/assets/f89fdf95-c41e-46b5-ada6-c9892d98d776" />

### Step 4 - see it on beeper without icon

<img width="500" height="65" alt="Screenshot 2026-05-17 at 16 40 58" src="https://github.com/user-attachments/assets/c178cd4f-a543-49d7-a442-d0358812b370" />

