### PR TITLE
ci: ♻️ skip Docker publish CI for forked PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
+    # Forked PRs and fork pushes don't have access to Beeper registry secrets.
+    if: ${{ github.repository == 'beeper/line' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Skip the Docker publish job outside the upstream `beeper/line` repo
- Avoid registry login/push on forked pull requests where GitHub does not expose registry secrets

Fixes #178

## Testing

- pre-commit run check-yaml --files .github/workflows/deploy.yml
- git diff --check