### PR TITLE
feat: ✨ bridge LINE Flex message fallbacks

### DIFF
--- a/pkg/connector/consts.go
+++ b/pkg/connector/consts.go
@@ -38,6 +38,7 @@ const (
 	ContentContact  ContentType = 13
 	ContentFile     ContentType = 14
 	ContentLocation ContentType = 15
+	ContentFlex     ContentType = 22
 )
 
 // ToType values for LINE message destinations.

--- a/pkg/connector/handle_message.go
+++ b/pkg/connector/handle_message.go
@@ -119,7 +119,7 @@ func (lc *LineClient) queueIncomingMessage(msg *line.Message, opType int) {
 func isBridgeableContentType(msg *line.Message) bool {
 	switch ContentType(msg.ContentType) {
 	case ContentText, ContentImage, ContentVideo, ContentAudio,
-		ContentSticker, ContentContact, ContentFile, ContentLocation:
+		ContentSticker, ContentContact, ContentFile, ContentLocation, ContentFlex:
 		return true
 	default:
 		return msg.ContentMetadata["ORGCONTP"] == "CALL" || msg.ContentMetadata["ORGCONTP"] == "CONTACT"
@@ -290,6 +290,8 @@ func (lc *LineClient) convertLineMessage(ctx context.Context, portal *bridgev2.P
 		return h.ConvertLocation(data, replyRelatesTo)
 	case ContentContact:
 		return h.ConvertContact(data, replyRelatesTo)
+	case ContentFlex:
+		return h.ConvertFlex(data, replyRelatesTo)
 	}
 
 	// Handle device/phone contact shared via ORGCONTP (contentType 0 with vCard)

--- a/pkg/connector/handlers/flex.go
+++ b/pkg/connector/handlers/flex.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"strings"
+
+	"maunium.net/go/mautrix/bridgev2"
+	"maunium.net/go/mautrix/event"
+
+	"github.com/highesttt/matrix-line-messenger/pkg/line"
+)
+
+// ConvertFlex converts a LINE rich/Flex message to a Matrix fallback.
+func (h *Handler) ConvertFlex(data line.Message, relatesTo *event.RelatesTo) (*bridgev2.ConvertedMessage, error) {
+	preview := strings.TrimSpace(data.ContentMetadata["ALT_TEXT"])
+	body := "LINE rich message. Check LINE for full details."
+	if preview != "" {
+		body += "\n\nPreview:\n" + preview
+	}
+
+	return &bridgev2.ConvertedMessage{
+		Parts: []*bridgev2.ConvertedMessagePart{
+			{
+				Type: event.EventMessage,
+				Content: &event.MessageEventContent{
+					MsgType:   event.MsgNotice,
+					Body:      body,
+					RelatesTo: relatesTo,
+				},
+			},
+		},
+	}, nil
+}


### PR DESCRIPTION
## Summary

- Treat LINE content type 22 as bridgeable
- Bridge Flex/bot messages as Matrix notices that tell users to check LINE for full details
- Include `ALT_TEXT` as a preview when LINE provides it

Fixes #126

## Testing

- go test ./pkg/connector
- git diff --check