### PR TITLE
Allow Docker CI to build fork PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
+    env:
+      HAS_DOCKER_REGISTRY_CREDS: ${{ secrets.CI_REGISTRY != '' && secrets.CI_REGISTRY_USER != '' && secrets.CI_REGISTRY_PASSWORD != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -78,6 +80,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to registry
+        if: env.HAS_DOCKER_REGISTRY_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.CI_REGISTRY }}
@@ -85,6 +88,17 @@ jobs:
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
 
       - name: Docker Build
+        if: env.HAS_DOCKER_REGISTRY_CREDS != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          pull: true
+          file: Dockerfile
+          tags: matrix-line:${{ github.sha }}
+          push: false
+
+      - name: Docker Build and Push
+        if: env.HAS_DOCKER_REGISTRY_CREDS == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
## Summary

- skip the private Docker registry login when registry secrets are unavailable
- run a build-only Docker path for fork PRs without pushing an image
- keep the existing login, cache, tag, and push behavior when registry credentials are present

## Testing

- parsed `.github/workflows/deploy.yml` as YAML locally
- `git diff --check`
- `docker build -t matrix-line-ci-fork-pr .`

## Notes

Fork PRs do not receive repository secrets, so the existing `build-docker` job failed before building with `Username and password required`. This keeps the Docker build check useful for forks while preserving image pushes for trusted runs with registry credentials.